### PR TITLE
Event hosting activity

### DIFF
--- a/bubbletracksapp/app/src/main/java/com/example/bubbletracksapp/Event.java
+++ b/bubbletracksapp/app/src/main/java/com/example/bubbletracksapp/Event.java
@@ -3,9 +3,14 @@ package com.example.bubbletracksapp;
 import android.location.Location;
 import android.media.Image;
 
+import java.sql.Time;
+import java.util.Calendar;
+import java.util.Formatter;
+
 public class Event {
     private String name;
     private String description;
+    private Calendar date;
     //QRCode should probably be another type of field INCOMPLETE
     private String QRCode;
     private Location geolocation;
@@ -65,4 +70,38 @@ public class Event {
         return QRCode;
     }
 
+    public Calendar getDate() {
+        return date;
+    }
+
+    public void setDate(Calendar date) {
+        this.date = date;
+    }
+
+    public String getMonth() {
+        Formatter format = new Formatter();
+        format.format("%tb", date);
+        return format.toString();
+
+    }
+
+    public String getDay() {
+        Formatter format = new Formatter();
+        format.format("%tm", date);
+        return format.toString();
+
+    }
+
+    public String getTime() {
+        Formatter format = new Formatter();
+        format.format("%tl:%tM", date, date);
+        return format.toString();
+
+    }
+
+    //Should return a specific address
+    public String getLocation() {
+        return "Ualberta 10001";
+
+    }
 }

--- a/bubbletracksapp/app/src/main/java/com/example/bubbletracksapp/Event.java
+++ b/bubbletracksapp/app/src/main/java/com/example/bubbletracksapp/Event.java
@@ -4,6 +4,7 @@ import android.location.Location;
 import android.media.Image;
 
 import java.sql.Time;
+import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Formatter;
 
@@ -16,6 +17,10 @@ public class Event {
     private Location geolocation;
     private Image image;
     private boolean needsGeolocation;
+    private ArrayList<Entrant> waitList = new ArrayList<>();
+    private ArrayList<Entrant> invitedList = new ArrayList<>();
+    private ArrayList<Entrant> cancelledList = new ArrayList<>();
+    private ArrayList<Entrant> rejectedList = new ArrayList<>();
 
 
     public String getName() {
@@ -103,5 +108,68 @@ public class Event {
     public String getLocation() {
         return "Ualberta 10001";
 
+    }
+
+    public ArrayList<Entrant> getWaitList() {
+        return waitList;
+    }
+
+    public void setWaitList(ArrayList<Entrant> waitList) {
+        this.waitList = waitList;
+    }
+
+    public void addToWaitList(Entrant entrant) {
+        this.waitList.add(entrant);
+    }
+
+    public void deleteFromWaitList(Entrant entrant) {
+        this.waitList.remove(entrant);
+    }
+
+    public ArrayList<Entrant> getInvitedList() {
+        return invitedList;
+    }
+
+    public void setInvitedList(ArrayList<Entrant> invitedList) {
+        this.invitedList = invitedList;
+    }
+
+    public void addToInvitedList(Entrant entrant) {
+        this.invitedList.add(entrant);
+    }
+
+    public void deleteFromInvitedList(Entrant entrant) {
+        this.invitedList.remove(entrant);
+    }
+
+    public ArrayList<Entrant> getCancelledList() {
+        return cancelledList;
+    }
+
+    public void setCancelledList(ArrayList<Entrant> cancelledList) {
+        this.cancelledList = cancelledList;
+    }
+
+    public void addToCancelledList(Entrant entrant) {
+        this.cancelledList.add(entrant);
+    }
+
+    public void deleteFromCancelledList(Entrant entrant) {
+        this.cancelledList.remove(entrant);
+    }
+
+    public ArrayList<Entrant> getRejectedList() {
+        return rejectedList;
+    }
+
+    public void setRejectedList(ArrayList<Entrant> rejectedList) {
+        this.rejectedList = rejectedList;
+    }
+    public void addToRejectedList(Entrant entrant) {
+        this.rejectedList.add(entrant);
+    }
+
+    public void deleteFromRejectedList(Entrant entrant) {
+        this.rejectedList.remove(entrant);
     }
 }

--- a/bubbletracksapp/app/src/main/java/com/example/bubbletracksapp/EventHostListAdapter.java
+++ b/bubbletracksapp/app/src/main/java/com/example/bubbletracksapp/EventHostListAdapter.java
@@ -1,0 +1,77 @@
+package com.example.bubbletracksapp;
+
+import android.content.Context;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.ArrayAdapter;
+import android.widget.Button;
+import android.widget.TextView;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import java.util.ArrayList;
+
+public class EventHostListAdapter extends ArrayAdapter<Event>{
+    interface EventHostI {
+        void viewWaitlist(Event event);
+        void editEvent(Event event);
+    }
+    private EventHostI listener;
+
+    public EventHostListAdapter(Context context, ArrayList<Event> events) {
+        super(context, 0, events);
+        if (context instanceof EventHostI) {
+            listener = (EventHostI) context;
+        } else {
+            throw new RuntimeException(context + " must implement EventHostI");
+        }
+    }
+
+    @NonNull
+    @Override
+    public View getView(int position, @Nullable View convertView, @NonNull ViewGroup parent) {
+        View view;
+        if (convertView == null) {
+            view = LayoutInflater.from(getContext()).inflate(R.layout.event_hosting_item,
+                    parent, false);
+        } else {
+            view = convertView;
+        }
+        Event event = getItem(position);
+
+        TextView eventMonthText = view.findViewById(R.id.event_month);
+        TextView eventDateText = view.findViewById(R.id.event_date);
+        TextView eventTimeText = view.findViewById(R.id.event_time);
+        TextView eventLocationText = view.findViewById(R.id.event_location);
+        TextView eventTitleText = view.findViewById(R.id.event_title);
+
+        Button seePeopleButton = view.findViewById(R.id.see_people_button);
+        Button editEventButton = view.findViewById(R.id.edit_event_button);
+
+
+        eventMonthText.setText(event.getMonth());
+        eventDateText.setText(event.getDay());
+        eventTimeText.setText(event.getTime());
+        eventLocationText.setText(event.getLocation());
+        eventTitleText.setText(event.getName());
+
+        seePeopleButton.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                listener.viewWaitlist(event);
+            }
+        });
+
+        editEventButton.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                listener.editEvent(event);
+            }
+        });
+
+
+        return view;
+    }
+}

--- a/bubbletracksapp/app/src/main/java/com/example/bubbletracksapp/EventHostListAdapter.java
+++ b/bubbletracksapp/app/src/main/java/com/example/bubbletracksapp/EventHostListAdapter.java
@@ -1,6 +1,7 @@
 package com.example.bubbletracksapp;
 
 import android.content.Context;
+import android.content.Intent;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -78,6 +79,15 @@ public class EventHostListAdapter extends ArrayAdapter<Event>{
     }
 
     public void viewWaitlist(Event event) {
+        Context context = EventHostListAdapter.this.getContext();
+
+        Intent intent = new Intent(EventHostListAdapter.this.getContext(), OrganizerEditActivity.class);
+        intent.putParcelableArrayListExtra("wait", event.getWaitList());
+        intent.putParcelableArrayListExtra("invited", event.getInvitedList());
+        intent.putParcelableArrayListExtra("rejected", event.getRejectedList());
+        intent.putParcelableArrayListExtra("cancelled", event.getCancelledList());
+
+        context.startActivity(intent);
 
     }
 

--- a/bubbletracksapp/app/src/main/java/com/example/bubbletracksapp/EventHostListAdapter.java
+++ b/bubbletracksapp/app/src/main/java/com/example/bubbletracksapp/EventHostListAdapter.java
@@ -10,23 +10,25 @@ import android.widget.TextView;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.appcompat.widget.AppCompatButton;
+import androidx.appcompat.widget.AppCompatImageButton;
 
 import java.util.ArrayList;
 
 public class EventHostListAdapter extends ArrayAdapter<Event>{
-    interface EventHostI {
-        void viewWaitlist(Event event);
-        void editEvent(Event event);
-    }
-    private EventHostI listener;
+//    interface EventHostI {
+//        void viewWaitlist(Event event);
+//        void editEvent(Event event);
+//    }
+//    private EventHostI listener;
 
     public EventHostListAdapter(Context context, ArrayList<Event> events) {
         super(context, 0, events);
-        if (context instanceof EventHostI) {
-            listener = (EventHostI) context;
-        } else {
-            throw new RuntimeException(context + " must implement EventHostI");
-        }
+//        if (context instanceof EventHostI) {
+//            listener = (EventHostI) context;
+//        } else {
+//            throw new RuntimeException(context + " must implement EventHostI");
+//        }
     }
 
     @NonNull
@@ -47,8 +49,8 @@ public class EventHostListAdapter extends ArrayAdapter<Event>{
         TextView eventLocationText = view.findViewById(R.id.event_location);
         TextView eventTitleText = view.findViewById(R.id.event_title);
 
-        Button seePeopleButton = view.findViewById(R.id.see_people_button);
-        Button editEventButton = view.findViewById(R.id.edit_event_button);
+        AppCompatImageButton seePeopleButton = view.findViewById(R.id.see_people_button);
+        AppCompatImageButton editEventButton = view.findViewById(R.id.edit_event_button);
 
 
         eventMonthText.setText(event.getMonth());
@@ -60,18 +62,27 @@ public class EventHostListAdapter extends ArrayAdapter<Event>{
         seePeopleButton.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
-                listener.viewWaitlist(event);
+                viewWaitlist(event);
             }
         });
 
         editEventButton.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
-                listener.editEvent(event);
+                editEvent(event);
             }
         });
 
 
         return view;
     }
+
+    public void viewWaitlist(Event event) {
+
+    }
+
+    public void editEvent(Event event) {
+
+    }
+
 }

--- a/bubbletracksapp/app/src/main/java/com/example/bubbletracksapp/MainActivity.java
+++ b/bubbletracksapp/app/src/main/java/com/example/bubbletracksapp/MainActivity.java
@@ -1,5 +1,7 @@
 package com.example.bubbletracksapp;
 
+import android.app.FragmentManager;
+import android.app.FragmentTransaction;
 import android.os.Bundle;
 
 import com.example.bubbletracksapp.databinding.HomescreenBinding;
@@ -30,6 +32,14 @@ public class MainActivity extends AppCompatActivity {
 
         binding = HomescreenBinding.inflate(getLayoutInflater());
         setContentView(binding.getRoot());
+
+        if (savedInstanceState == null) {
+            getSupportFragmentManager().beginTransaction()
+                    .setReorderingAllowed(true)
+                    .add(R.id.content_holder, OrganizerEventHosting.class, null)
+                    .commit();
+        }
+
 
     }
 

--- a/bubbletracksapp/app/src/main/java/com/example/bubbletracksapp/OrganizerEditActivity.java
+++ b/bubbletracksapp/app/src/main/java/com/example/bubbletracksapp/OrganizerEditActivity.java
@@ -4,16 +4,17 @@ import android.content.Intent;
 import android.os.Bundle;;
 import android.view.View;
 import android.widget.ArrayAdapter;
-import android.widget.EditText;
 import android.widget.ListView;
+import android.widget.Spinner;
 
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
 
-import com.example.bubbletracksapp.databinding.OrganizerWaitlistSampleBinding;
+import com.example.bubbletracksapp.databinding.LotteryMainBinding;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 
 /**
  * Allows the organizer to sample N entrants from the waitlist.
@@ -33,12 +34,12 @@ public class OrganizerEditActivity extends AppCompatActivity {
     ArrayAdapter<String> waitlistAdapter;
 
 
-    private OrganizerWaitlistSampleBinding binding;
+    private LotteryMainBinding binding;
 
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        binding = OrganizerWaitlistSampleBinding.inflate(getLayoutInflater());
+        binding = LotteryMainBinding.inflate(getLayoutInflater());
         setContentView(binding.getRoot());
 
 
@@ -59,56 +60,37 @@ public class OrganizerEditActivity extends AppCompatActivity {
         }
 
 
-        // TEMP FUNCTION TO ADD ENTANS, SHOULD BE CHANGED TO GET fom LAST INTENT INCOMPLETE
-        if(in.getParcelableArrayListExtra("wait") == null) {
-            Entrant en = new Entrant();
-            en.setName("hola", " tata");
-            waitList.add(en);
-
-            en = new Entrant();
-            en.setName("ches", " tata");
-            waitList.add(en);
-
-            en = new Entrant();
-            en.setName("zoe", " tata");
-            waitList.add(en);
-
-            en = new Entrant();
-            en.setName("sam", " tata");
-            waitList.add(en);
-
-            en = new Entrant();
-            en.setName("eaaaa", " tata");
-            cancelledList.add(en);
-            en = new Entrant();
-            en.setName("misete", " tata");
-            cancelledList.add(en);
-
-        }
-
         for (int i = 0; i < waitList.size(); i++) {
             waitListArray.add(waitList.get(i).getNameAsString());
         }
 
-        waitlistListView = binding.waitlistSample;
+        waitlistListView = binding.reusableListView;
         waitlistAdapter = new ArrayAdapter<String>(this.getApplicationContext(), R.layout.list_simple_view,  waitListArray);
         waitlistListView.setAdapter(waitlistAdapter);
 
 
-        binding.drawEntrants.setOnClickListener(new View.OnClickListener() {
+        Spinner nSpinner = binding.waitlistChooseCount;
+        List<String> spinList = new ArrayList<String>();
+        for (int i=1; i<=waitList.size(); i++){
+            spinList.add(String.valueOf(i));
+        }
+        ArrayAdapter<String> spinAdapter = new ArrayAdapter<String>(this, android.R.layout.simple_spinner_item, spinList);
+        spinAdapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
+        nSpinner.setAdapter(spinAdapter);
+
+        binding.chooseFromWaitlistButton.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
-                EditText nText = binding.numberToDraw;
-                String nStr = nText.getText().toString();
+                Spinner nSpin = binding.waitlistChooseCount;
+                String nStr = nSpin.getSelectedItem().toString();
                 int n = Integer.parseInt(nStr);
                 drawEntrants(n);
                 startListActivity();
-
             }
         });
 
 
-        binding.backTo1.setOnClickListener(new View.OnClickListener() {
+        binding.backButton.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
                 // Filled with going to the last activity. INCOMPLETE

--- a/bubbletracksapp/app/src/main/java/com/example/bubbletracksapp/OrganizerEntrantListActivity.java
+++ b/bubbletracksapp/app/src/main/java/com/example/bubbletracksapp/OrganizerEntrantListActivity.java
@@ -4,13 +4,12 @@ import android.content.Intent;
 import android.os.Bundle;
 import android.util.Log;
 import android.view.View;
-import android.widget.ArrayAdapter;
 import android.widget.ListView;
 
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
 
-import com.example.bubbletracksapp.databinding.OrganizerWaitlistBinding;
+import com.example.bubbletracksapp.databinding.LotteryMainExtendBinding;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -25,7 +24,7 @@ import java.util.Collections;
  */
 public class OrganizerEntrantListActivity extends AppCompatActivity implements CancelledListAdapter.CancelledEntrantI {
 
-    private OrganizerWaitlistBinding binding;
+    private LotteryMainExtendBinding binding;
 
     //To be changed to waitlist class INCOMPLETE
     // waitList contains all the entrants that joined the waitlist
@@ -58,7 +57,7 @@ public class OrganizerEntrantListActivity extends AppCompatActivity implements C
     public void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
-        binding = OrganizerWaitlistBinding.inflate(getLayoutInflater());
+        binding = LotteryMainExtendBinding.inflate(getLayoutInflater());
         setContentView(binding.getRoot());
 
         // INCOMPLETE
@@ -76,20 +75,20 @@ public class OrganizerEntrantListActivity extends AppCompatActivity implements C
             cancelledList.addAll(in.getParcelableArrayListExtra("cancelled"));
         }
 
-        waitlistListView = binding.waitlistList;
+        waitlistListView = binding.waitlistView;
         waitlistAdapter = new EntrantListAdapter(this, waitList);
         waitlistListView.setAdapter(waitlistAdapter);
 
-        invitedListView = binding.invitedList;
+        invitedListView = binding.invitedListView;
         invitedAdapter = new InvitedListAdapter(this, invitedList);
         invitedListView.setAdapter(invitedAdapter);
 
-        cancelledListView = binding.rejectedList;
+        cancelledListView = binding.cancelledListView;
         cancelledAdapter = new CancelledListAdapter(this, cancelledList);
         cancelledListView.setAdapter(cancelledAdapter);
         Log.d("TAG", "onViewCreated: ");
 
-        binding.toSampleButton.setOnClickListener(new View.OnClickListener() {
+        binding.backButton.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
                 Intent intent = new Intent(OrganizerEntrantListActivity.this, OrganizerEditActivity.class);

--- a/bubbletracksapp/app/src/main/java/com/example/bubbletracksapp/OrganizerEventHosting.java
+++ b/bubbletracksapp/app/src/main/java/com/example/bubbletracksapp/OrganizerEventHosting.java
@@ -1,0 +1,126 @@
+package com.example.bubbletracksapp;
+//
+//import android.content.Intent;
+//import android.os.Bundle;
+//import android.view.View;
+//
+//import androidx.annotation.Nullable;
+//import androidx.appcompat.app.AppCompatActivity;
+//
+//import com.example.bubbletracksapp.databinding.OrganizerEventHostingBinding;
+//
+//public class OrganizerEventHosting extends AppCompatActivity {
+//    private OrganizerEventHostingBinding binding;
+//
+//
+//    @Override
+//    protected void onCreate(@Nullable Bundle savedInstanceState) {
+//        super.onCreate(savedInstanceState);
+//        binding = OrganizerEventHostingBinding.inflate(getLayoutInflater());
+//        setContentView(binding.getRoot());
+//
+//
+//
+//        binding.waitlistButton.setOnClickListener(new View.OnClickListener() {
+//            @Override
+//            public void onClick(View view) {
+//                Intent intent = new Intent(OrganizerEventHosting.this, OrganizerEditActivity.class);
+//                intent.putParcelableArrayListExtra("wait", waitList);
+//                intent.putParcelableArrayListExtra("invited", invitedList);
+//                intent.putParcelableArrayListExtra("rejected", rejectedList);
+//                intent.putParcelableArrayListExtra("cancelled", cancelledList);
+//
+//                startActivity(intent);
+//            }
+//        });
+//
+//    }
+//}
+
+
+import android.content.Intent;
+import android.os.Bundle;
+import android.util.Log;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.ListView;
+
+import androidx.annotation.NonNull;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.fragment.app.Fragment;
+import androidx.navigation.fragment.NavHostFragment;
+
+import com.example.bubbletracksapp.databinding.FragmentFirstBinding;
+import com.example.bubbletracksapp.databinding.ListsBinding;
+
+import java.util.ArrayList;
+import java.util.Calendar;
+
+public class OrganizerEventHosting extends Fragment{
+    private ListsBinding binding;
+
+    ArrayList<Event> hostedEvents = new ArrayList<>();
+
+    ListView eventListView;
+    EventHostListAdapter eventListAdapter;
+
+    @Override
+    public View onCreateView(
+            @NonNull LayoutInflater inflater, ViewGroup container,
+            Bundle savedInstanceState
+    ) {
+
+        binding = ListsBinding.inflate(inflater, container, false);
+        return binding.getRoot();
+
+    }
+
+    public void onViewCreated(@NonNull View view, Bundle savedInstanceState) {
+        super.onViewCreated(view, savedInstanceState);
+
+        Event e = new Event();
+        e.setName("Nathacks");
+        Calendar c = Calendar.getInstance();
+        e.setDate(c);
+        hostedEvents.add(e);
+
+        e = new Event();
+        e.setName("eaaaa");
+        c = Calendar.getInstance();
+        e.setDate(c);
+        hostedEvents.add(e);
+
+        Log.d("TAG", view.getContext().toString());
+        eventListView = binding.reusableListView;
+        eventListAdapter = new EventHostListAdapter(this.getContext(), hostedEvents);
+        eventListView.setAdapter(eventListAdapter);
+        //        waitlistListView = binding.waitlistList;
+        //        waitlistAdapter = new EntrantListAdapter(this, waitList);
+        //        waitlistListView.setAdapter(waitlistAdapter);
+        //
+        //
+
+//        binding.reusableListView.setOnClickListener(new View.OnClickListener() {
+//            @Override
+//            public void onClick(View view) {
+//                Intent intent = new Intent(OrganizerEventHosting.this, OrganizerEditActivity.class);
+//                intent.putParcelableArrayListExtra("wait", waitList);
+//                intent.putParcelableArrayListExtra("invited", invitedList);
+//                intent.putParcelableArrayListExtra("rejected", rejectedList);
+//                intent.putParcelableArrayListExtra("cancelled", cancelledList);
+//
+//                startActivity(intent);
+//            }
+//        });
+
+    }
+
+    @Override
+    public void onDestroyView() {
+        super.onDestroyView();
+        binding = null;
+    }
+
+
+}

--- a/bubbletracksapp/app/src/main/java/com/example/bubbletracksapp/OrganizerEventHosting.java
+++ b/bubbletracksapp/app/src/main/java/com/example/bubbletracksapp/OrganizerEventHosting.java
@@ -83,6 +83,30 @@ public class OrganizerEventHosting extends Fragment{
         e.setName("Nathacks");
         Calendar c = Calendar.getInstance();
         e.setDate(c);
+
+        Entrant en = new Entrant();
+        en.setName("hola", " tata");
+        e.addToWaitList(en);
+
+        en = new Entrant();
+        en.setName("ches", " tata");
+        e.addToWaitList(en);
+
+        en = new Entrant();
+        en.setName("zoe", " tata");
+        e.addToWaitList(en);
+
+        en = new Entrant();
+        en.setName("sam", " tata");
+        e.addToWaitList(en);
+
+        en = new Entrant();
+        en.setName("eaaaa", " tata");
+        e.addToCancelledList(en);
+        en = new Entrant();
+        en.setName("misete", " tata");
+        e.addToCancelledList(en);
+
         hostedEvents.add(e);
 
         e = new Event();
@@ -91,28 +115,33 @@ public class OrganizerEventHosting extends Fragment{
         e.setDate(c);
         hostedEvents.add(e);
 
+        en.setName("hola", " tata");
+        e.addToWaitList(en);
+
+        en = new Entrant();
+        en.setName("ches", " tata");
+        e.addToWaitList(en);
+
+        en = new Entrant();
+        en.setName("zoe", " tata");
+        e.addToWaitList(en);
+
+        en = new Entrant();
+        en.setName("sam", " tata");
+        e.addToWaitList(en);
+
+        en = new Entrant();
+        en.setName("eaaaa", " tata");
+        e.addToCancelledList(en);
+        en = new Entrant();
+        en.setName("misete", " tata");
+        e.addToCancelledList(en);
+
         Log.d("TAG", view.getContext().toString());
         eventListView = binding.reusableListView;
         eventListAdapter = new EventHostListAdapter(this.getContext(), hostedEvents);
         eventListView.setAdapter(eventListAdapter);
-        //        waitlistListView = binding.waitlistList;
-        //        waitlistAdapter = new EntrantListAdapter(this, waitList);
-        //        waitlistListView.setAdapter(waitlistAdapter);
-        //
-        //
 
-//        binding.reusableListView.setOnClickListener(new View.OnClickListener() {
-//            @Override
-//            public void onClick(View view) {
-//                Intent intent = new Intent(OrganizerEventHosting.this, OrganizerEditActivity.class);
-//                intent.putParcelableArrayListExtra("wait", waitList);
-//                intent.putParcelableArrayListExtra("invited", invitedList);
-//                intent.putParcelableArrayListExtra("rejected", rejectedList);
-//                intent.putParcelableArrayListExtra("cancelled", cancelledList);
-//
-//                startActivity(intent);
-//            }
-//        });
 
     }
 

--- a/bubbletracksapp/app/src/main/res/layout/lottery_main.xml
+++ b/bubbletracksapp/app/src/main/res/layout/lottery_main.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ScrollView
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
@@ -81,10 +82,11 @@
 
             <Spinner
                 android:id="@+id/waitlistChooseCount"
-                android:layout_width="48dp"
+                android:layout_width="wrap_content"
                 android:layout_height="48dp"
+                android:layout_marginStart="8dp"
                 android:background="@drawable/round_event"
-                android:layout_marginStart="8dp" />
+                android:visibility="visible" />
         </LinearLayout>
     </LinearLayout>
 </ScrollView>

--- a/bubbletracksapp/app/src/main/res/layout/lottery_main_extend.xml
+++ b/bubbletracksapp/app/src/main/res/layout/lottery_main_extend.xml
@@ -63,10 +63,29 @@
             android:layout_marginTop="16dp"/>
         <!--After drawing from list, change visibility  when needed-->
         <!--android:visibility="gone"-->
-            <ListView
-                android:layout_width="match_parent"
-                android:layout_height="match_parent">
-            </ListView>
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:layout_marginTop="8dp"
+            android:gravity="center"
+            android:orientation="horizontal">
+
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="end"
+                android:gravity="center"
+                android:padding="8dp"
+                android:text="Invited"
+                android:textColor="#B41313"
+                android:textSize="30dp" />
+        </LinearLayout>
+
+        <ListView
+            android:id="@+id/invited_list_view"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"></ListView>
 
             <Button
                 android:id="@+id/notifyWinnersButton"
@@ -93,14 +112,6 @@
                 android:padding="8dp"
                 android:layout_gravity="end"
                 android:gravity= "center"/>
-            <androidx.appcompat.widget.AppCompatButton
-                android:id="@+id/redraw_button"
-                android:layout_width="wrap_content"
-                android:layout_height="40dp"
-                android:background="@drawable/round_event"
-                android:text="Redraw"
-                android:layout_margin="8dp"
-                android:backgroundTint="#34B140"/>
         </LinearLayout>
             <ListView
                 android:id="@+id/cancelled_list_view"

--- a/bubbletracksapp/app/src/main/res/layout/name_button_list.xml
+++ b/bubbletracksapp/app/src/main/res/layout/name_button_list.xml
@@ -12,17 +12,20 @@
             android:id="@+id/left_text_view"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_weight="1"
+            android:layout_marginTop="3dp"
+            android:layout_weight="0.5"
             android:text="TextView"
             android:textAlignment="center"
             android:textSize="24sp" />
 
-        <Button
+        <androidx.appcompat.widget.AppCompatButton
             android:id="@+id/right_button_view"
             android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_weight="1"
-            android:text="Button"
-            android:textSize="24sp" />
+            android:layout_height="40dp"
+            android:layout_margin="0dp"
+            android:layout_weight="0.5"
+            android:background="@drawable/round_event"
+            android:backgroundTint="#34B140"
+            android:text="Redraw" />
     </LinearLayout>
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
Closes #20.
Sets up the event hosting tab that contains the events the Organizer is hosting. If you click on the image button with people it will redirect you to sampling from the lottery and then showing the waitlists.
It has a test function that just adds two events with the current date and the same waitlist, should be changed later.
To test just run it, the main activity should be changed but that will be done once someone sets up the homepage.
