### PR TITLE
Cancel and status entrants

### DIFF
--- a/bubbletracksapp/app/src/main/java/com/example/bubbletracksapp/Entrant.java
+++ b/bubbletracksapp/app/src/main/java/com/example/bubbletracksapp/Entrant.java
@@ -10,6 +10,7 @@ import androidx.annotation.NonNull;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 
 public class Entrant implements Parcelable {
     /**
@@ -106,5 +107,19 @@ public class Entrant implements Parcelable {
         parcel.writeStringArray(name);
         parcel.writeString(email);
         parcel.writeString(phone);
+    }
+
+    // Will need to be updated after changing the fields. May be easy to just use the device ID.
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Entrant entrant = (Entrant) o;
+        return Objects.deepEquals(name, entrant.name) && Objects.equals(email, entrant.email) && Objects.equals(phone, entrant.phone) && Objects.equals(deviceID, entrant.deviceID);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(Arrays.hashCode(name), email, phone, deviceID);
     }
 }

--- a/bubbletracksapp/app/src/main/java/com/example/bubbletracksapp/Event.java
+++ b/bubbletracksapp/app/src/main/java/com/example/bubbletracksapp/Event.java
@@ -20,6 +20,7 @@ public class Event {
     private ArrayList<Entrant> invitedList = new ArrayList<>();
     private ArrayList<Entrant> cancelledList = new ArrayList<>();
     private ArrayList<Entrant> rejectedList = new ArrayList<>();
+    private ArrayList<Entrant> enrolledList = new ArrayList<>();
 
 
     public String getName() {
@@ -172,4 +173,25 @@ public class Event {
     public void deleteFromRejectedList(Entrant entrant) {
         this.rejectedList.remove(entrant);
     }
+
+    public ArrayList<Entrant> getEnrolledList() {
+        return enrolledList;
+    }
+
+    public void setEnrolledList(ArrayList<Entrant> enrolledList) {
+        this.enrolledList = enrolledList;
+    }
+
+    public void addToEnrolledList(Entrant entrant) {
+        this.enrolledList.add(entrant);
+    }
+
+    public void deleteFromEnrolledList(Entrant entrant) {
+        this.enrolledList.remove(entrant);
+    }
+
+    public boolean isInEnrolledList(Entrant entrant){
+        return this.enrolledList.contains(entrant);
+    }
+
 }

--- a/bubbletracksapp/app/src/main/java/com/example/bubbletracksapp/Event.java
+++ b/bubbletracksapp/app/src/main/java/com/example/bubbletracksapp/Event.java
@@ -2,12 +2,15 @@ package com.example.bubbletracksapp;
 
 import android.location.Location;
 import android.media.Image;
+import android.os.Parcel;
+import android.os.Parcelable;
+import android.util.Log;
 
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Formatter;
 
-public class Event {
+public class Event implements Parcelable {
     private String name;
     private String description;
     private Calendar date;
@@ -22,6 +25,70 @@ public class Event {
     private ArrayList<Entrant> rejectedList = new ArrayList<>();
     private ArrayList<Entrant> enrolledList = new ArrayList<>();
 
+
+    public Event(){
+        Log.w("NewEvent", "Event has empty strings for information.");
+    }
+
+    public Event(String name, String description, Calendar date, String QRCode, Location geolocation, Image image, boolean needsGeolocation, ArrayList<Entrant> waitList, ArrayList<Entrant> invitedList, ArrayList<Entrant> cancelledList, ArrayList<Entrant> rejectedList, ArrayList<Entrant> enrolledList) {
+        this.name = name;
+        this.description = description;
+        this.date = date;
+        this.QRCode = QRCode;
+        this.geolocation = geolocation;
+        this.image = image;
+        this.needsGeolocation = needsGeolocation;
+        this.waitList = waitList;
+        this.invitedList = invitedList;
+        this.cancelledList = cancelledList;
+        this.rejectedList = rejectedList;
+        this.enrolledList = enrolledList;
+    }
+
+
+    protected Event(Parcel in) {
+        name = in.readString();
+        description = in.readString();
+        QRCode = in.readString();
+        geolocation = in.readParcelable(Location.class.getClassLoader());
+        needsGeolocation = in.readByte() != 0;
+        waitList = in.createTypedArrayList(Entrant.CREATOR);
+        invitedList = in.createTypedArrayList(Entrant.CREATOR);
+        cancelledList = in.createTypedArrayList(Entrant.CREATOR);
+        rejectedList = in.createTypedArrayList(Entrant.CREATOR);
+        enrolledList = in.createTypedArrayList(Entrant.CREATOR);
+    }
+
+    @Override
+    public void writeToParcel(Parcel dest, int flags) {
+        dest.writeString(name);
+        dest.writeString(description);
+        dest.writeString(QRCode);
+        dest.writeParcelable(geolocation, flags);
+        dest.writeByte((byte) (needsGeolocation ? 1 : 0));
+        dest.writeTypedList(waitList);
+        dest.writeTypedList(invitedList);
+        dest.writeTypedList(cancelledList);
+        dest.writeTypedList(rejectedList);
+        dest.writeTypedList(enrolledList);
+    }
+
+    @Override
+    public int describeContents() {
+        return 0;
+    }
+
+    public static final Creator<Event> CREATOR = new Creator<Event>() {
+        @Override
+        public Event createFromParcel(Parcel in) {
+            return new Event(in);
+        }
+
+        @Override
+        public Event[] newArray(int size) {
+            return new Event[size];
+        }
+    };
 
     public String getName() {
         return name;
@@ -127,6 +194,10 @@ public class Event {
         this.waitList.remove(entrant);
     }
 
+    public void clearWaitList() {
+        this.waitList.clear();
+    }
+
     public ArrayList<Entrant> getInvitedList() {
         return invitedList;
     }
@@ -141,6 +212,10 @@ public class Event {
 
     public void deleteFromInvitedList(Entrant entrant) {
         this.invitedList.remove(entrant);
+    }
+
+    public void clearInvitedList() {
+        this.invitedList.clear();
     }
 
     public ArrayList<Entrant> getCancelledList() {
@@ -159,6 +234,10 @@ public class Event {
         this.cancelledList.remove(entrant);
     }
 
+    public void clearCancelledList() {
+        this.cancelledList.clear();
+    }
+
     public ArrayList<Entrant> getRejectedList() {
         return rejectedList;
     }
@@ -172,6 +251,10 @@ public class Event {
 
     public void deleteFromRejectedList(Entrant entrant) {
         this.rejectedList.remove(entrant);
+    }
+
+    public void clearRejectedList() {
+        this.rejectedList.clear();
     }
 
     public ArrayList<Entrant> getEnrolledList() {
@@ -188,6 +271,10 @@ public class Event {
 
     public void deleteFromEnrolledList(Entrant entrant) {
         this.enrolledList.remove(entrant);
+    }
+
+    public void clearEnrolledList() {
+        this.enrolledList.clear();
     }
 
     public boolean isInEnrolledList(Entrant entrant){

--- a/bubbletracksapp/app/src/main/java/com/example/bubbletracksapp/EventHostListAdapter.java
+++ b/bubbletracksapp/app/src/main/java/com/example/bubbletracksapp/EventHostListAdapter.java
@@ -82,10 +82,7 @@ public class EventHostListAdapter extends ArrayAdapter<Event>{
         Context context = EventHostListAdapter.this.getContext();
 
         Intent intent = new Intent(EventHostListAdapter.this.getContext(), OrganizerEditActivity.class);
-        intent.putParcelableArrayListExtra("wait", event.getWaitList());
-        intent.putParcelableArrayListExtra("invited", event.getInvitedList());
-        intent.putParcelableArrayListExtra("rejected", event.getRejectedList());
-        intent.putParcelableArrayListExtra("cancelled", event.getCancelledList());
+        intent.putExtra("event", event);
 
         context.startActivity(intent);
 

--- a/bubbletracksapp/app/src/main/java/com/example/bubbletracksapp/InvitedListAdapter.java
+++ b/bubbletracksapp/app/src/main/java/com/example/bubbletracksapp/InvitedListAdapter.java
@@ -1,6 +1,8 @@
 package com.example.bubbletracksapp;
 
+import android.app.AlertDialog;
 import android.content.Context;
+import android.content.DialogInterface;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -62,7 +64,25 @@ public class InvitedListAdapter extends ArrayAdapter<Entrant> {
         cancelEntrant.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
-                listener.cancelEntrant(entrant);
+                AlertDialog joinDialog;
+                joinDialog = new AlertDialog.Builder(getContext())
+                        .setTitle("Confirm Cancelling Entrant")
+                        .setMessage(String.format("Are you sure you want to cancel %s from this event?", entrant.getNameAsString()))
+                        .setPositiveButton("Confirm", new DialogInterface.OnClickListener() {
+                            @Override
+                            public void onClick(DialogInterface dialogInterface, int i) {
+                                listener.cancelEntrant(entrant);
+                                dialogInterface.dismiss();
+                            }
+                        })
+                        .setNegativeButton("Cancel", new DialogInterface.OnClickListener() {
+                            @Override
+                            public void onClick(DialogInterface dialogInterface, int i) {
+                                dialogInterface.dismiss();
+                            }
+                        })
+                        .create();
+                joinDialog.show();
             }
         });
         return view;

--- a/bubbletracksapp/app/src/main/java/com/example/bubbletracksapp/InvitedListAdapter.java
+++ b/bubbletracksapp/app/src/main/java/com/example/bubbletracksapp/InvitedListAdapter.java
@@ -5,16 +5,29 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ArrayAdapter;
+import android.widget.ImageButton;
 import android.widget.TextView;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.core.content.ContextCompat;
 
 import java.util.ArrayList;
 
 public class InvitedListAdapter extends ArrayAdapter<Entrant> {
+    interface InvitedEntrantI {
+        void cancelEntrant(Entrant entrant);
+        boolean hasEntrantAccepted(Entrant entrant);
+    }
+    private InvitedListAdapter.InvitedEntrantI listener;
+
     public InvitedListAdapter(Context context, ArrayList<Entrant> entrants) {
         super(context, 0, entrants);
+        if (context instanceof InvitedListAdapter.InvitedEntrantI) {
+            listener = (InvitedListAdapter.InvitedEntrantI) context;
+        } else {
+            throw new RuntimeException(context + " must implement InvitedEntrantI");
+        }
     }
 
     @NonNull
@@ -22,20 +35,36 @@ public class InvitedListAdapter extends ArrayAdapter<Entrant> {
     public View getView(int position, @Nullable View convertView, @NonNull ViewGroup parent) {
         View view;
         if (convertView == null) {
-            view = LayoutInflater.from(getContext()).inflate(R.layout.text_text_list,
+            view = LayoutInflater.from(getContext()).inflate(R.layout.attendee_status_item,
                     parent, false);
         } else {
             view = convertView;
         }
         Entrant entrant = getItem(position);
 
-        TextView entrantName = view.findViewById(R.id.left_text_view);
+        TextView entrantName = view.findViewById(R.id.attendee_name);
         entrantName.setText(entrant.getNameAsString());
 
-        TextView entrantState = view.findViewById(R.id.right_text_view);
-        // SHOULD BE CHANGED TO STATE WHETHER THE ENTRANT JOINED THE EVENT
-        entrantState.setText(entrant.getNameAsString());
+        TextView entrantState = view.findViewById(R.id.attendee_status);
+        // SHOULD BE UPDATED WHEN CHANGED IN FIEBASE INCOMPLETE
+        if (listener.hasEntrantAccepted(entrant)) {
+            entrantState.setText(R.string.enrolledEntrantState);
+            int color = ContextCompat.getColor(getContext(),R.color.positive);
+            entrantState.setTextColor(color);
+        }
+        else {
+            entrantState.setText(R.string.notEnrolledEntrantState);
+            int color = ContextCompat.getColor(getContext(),R.color.neutral);
+            entrantState.setTextColor(color);
+        }
 
+        ImageButton cancelEntrant = view.findViewById(R.id.cancel_entrant_button);
+        cancelEntrant.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                listener.cancelEntrant(entrant);
+            }
+        });
         return view;
     }
 }

--- a/bubbletracksapp/app/src/main/java/com/example/bubbletracksapp/OrganizerEditActivity.java
+++ b/bubbletracksapp/app/src/main/java/com/example/bubbletracksapp/OrganizerEditActivity.java
@@ -27,6 +27,7 @@ public class OrganizerEditActivity extends AppCompatActivity {
     ArrayList<Entrant> invitedList = new ArrayList<>();
     ArrayList<Entrant> rejectedList = new ArrayList<>();
     ArrayList<Entrant> cancelledList = new ArrayList<>();
+    ArrayList<Entrant> enrolledList = new ArrayList<>();
 
     ArrayList<String> waitListArray = new ArrayList<>();
 
@@ -57,6 +58,9 @@ public class OrganizerEditActivity extends AppCompatActivity {
         }
         if(in.getParcelableArrayListExtra("cancelled") != null) {
             cancelledList.addAll(in.getParcelableArrayListExtra("cancelled"));
+        }
+        if(in.getParcelableArrayListExtra("enrolled") != null) {
+            enrolledList.addAll(in.getParcelableArrayListExtra("enrolled"));
         }
 
 
@@ -112,6 +116,7 @@ public class OrganizerEditActivity extends AppCompatActivity {
         Collections.shuffle(waitList);
         invitedList.clear();
         rejectedList.clear();
+        enrolledList.clear();
         invitedList.addAll(waitList.subList(0, n));
         rejectedList.addAll(waitList.subList(n, waitList.size()));
 
@@ -125,6 +130,7 @@ public class OrganizerEditActivity extends AppCompatActivity {
         intent.putParcelableArrayListExtra("invited", invitedList);
         intent.putParcelableArrayListExtra("rejected", rejectedList);
         intent.putParcelableArrayListExtra("cancelled", cancelledList);
+        intent.putParcelableArrayListExtra("enrolled", enrolledList);
         startActivity(intent);
     }
 

--- a/bubbletracksapp/app/src/main/java/com/example/bubbletracksapp/OrganizerEditActivity.java
+++ b/bubbletracksapp/app/src/main/java/com/example/bubbletracksapp/OrganizerEditActivity.java
@@ -2,6 +2,7 @@ package com.example.bubbletracksapp;
 
 import android.content.Intent;
 import android.os.Bundle;;
+import android.util.Log;
 import android.view.View;
 import android.widget.ArrayAdapter;
 import android.widget.ListView;
@@ -23,6 +24,7 @@ import java.util.List;
  */
 public class OrganizerEditActivity extends AppCompatActivity {
     // SHOUL BE ENTant INCOMPLETE
+    Event event;
     ArrayList<Entrant> waitList = new ArrayList<>();
     ArrayList<Entrant> invitedList = new ArrayList<>();
     ArrayList<Entrant> rejectedList = new ArrayList<>();
@@ -47,21 +49,17 @@ public class OrganizerEditActivity extends AppCompatActivity {
 
         // INCOMPLETE
         Intent in =  getIntent();
-        if(in.getParcelableArrayListExtra("wait") != null) {
-            waitList.addAll(in.getParcelableArrayListExtra("wait"));
+        try {
+            event = in.getParcelableExtra("event");
+        } catch (Exception e) {
+            Log.d("OrganizerEditActivity", "event extra was not passed correctly");
+            throw new RuntimeException(e);
         }
-        if(in.getParcelableArrayListExtra("invited") != null) {
-            invitedList.addAll(in.getParcelableArrayListExtra("invited"));
-        }
-        if(in.getParcelableArrayListExtra("rejected") != null) {
-            rejectedList.addAll(in.getParcelableArrayListExtra("rejected"));
-        }
-        if(in.getParcelableArrayListExtra("cancelled") != null) {
-            cancelledList.addAll(in.getParcelableArrayListExtra("cancelled"));
-        }
-        if(in.getParcelableArrayListExtra("enrolled") != null) {
-            enrolledList.addAll(in.getParcelableArrayListExtra("enrolled"));
-        }
+        waitList = event.getWaitList();
+        invitedList = event.getInvitedList();
+        rejectedList = event.getRejectedList();
+        cancelledList = event.getCancelledList();
+        enrolledList = event.getEnrolledList();
 
 
         for (int i = 0; i < waitList.size(); i++) {
@@ -125,12 +123,13 @@ public class OrganizerEditActivity extends AppCompatActivity {
 
 
     private void startListActivity() {
+        event.setWaitList(waitList);
+        event.setInvitedList(invitedList);
+        event.setRejectedList(rejectedList);
+        event.setCancelledList(cancelledList);
+        event.setEnrolledList(enrolledList);
         Intent intent = new Intent(OrganizerEditActivity.this, OrganizerEntrantListActivity.class);
-        intent.putParcelableArrayListExtra("wait", waitList);
-        intent.putParcelableArrayListExtra("invited", invitedList);
-        intent.putParcelableArrayListExtra("rejected", rejectedList);
-        intent.putParcelableArrayListExtra("cancelled", cancelledList);
-        intent.putParcelableArrayListExtra("enrolled", enrolledList);
+        intent.putExtra("event", event);
         startActivity(intent);
     }
 

--- a/bubbletracksapp/app/src/main/java/com/example/bubbletracksapp/OrganizerEditActivity.java
+++ b/bubbletracksapp/app/src/main/java/com/example/bubbletracksapp/OrganizerEditActivity.java
@@ -23,7 +23,6 @@ import java.util.List;
  * @author Chester
  */
 public class OrganizerEditActivity extends AppCompatActivity {
-    // SHOUL BE ENTant INCOMPLETE
     Event event;
     ArrayList<Entrant> waitList = new ArrayList<>();
     ArrayList<Entrant> invitedList = new ArrayList<>();
@@ -31,10 +30,8 @@ public class OrganizerEditActivity extends AppCompatActivity {
     ArrayList<Entrant> cancelledList = new ArrayList<>();
     ArrayList<Entrant> enrolledList = new ArrayList<>();
 
-    ArrayList<String> waitListArray = new ArrayList<>();
-
     ListView waitlistListView;
-    ArrayAdapter<String> waitlistAdapter;
+    EntrantListAdapter waitlistAdapter;
 
 
     private LotteryMainBinding binding;
@@ -45,9 +42,6 @@ public class OrganizerEditActivity extends AppCompatActivity {
         binding = LotteryMainBinding.inflate(getLayoutInflater());
         setContentView(binding.getRoot());
 
-
-
-        // INCOMPLETE
         Intent in =  getIntent();
         try {
             event = in.getParcelableExtra("event");
@@ -61,13 +55,13 @@ public class OrganizerEditActivity extends AppCompatActivity {
         cancelledList = event.getCancelledList();
         enrolledList = event.getEnrolledList();
 
-
-        for (int i = 0; i < waitList.size(); i++) {
-            waitListArray.add(waitList.get(i).getNameAsString());
+        if(invitedList.size() > 0)
+        {
+            // Go to homescreen
         }
 
         waitlistListView = binding.reusableListView;
-        waitlistAdapter = new ArrayAdapter<String>(this.getApplicationContext(), R.layout.list_simple_view,  waitListArray);
+        waitlistAdapter = new EntrantListAdapter(this, waitList);
         waitlistListView.setAdapter(waitlistAdapter);
 
 
@@ -103,7 +97,7 @@ public class OrganizerEditActivity extends AppCompatActivity {
 
 
     // should return error if n is bigger than the size of waitlist INCOMPLETE
-    // Assuming it is the fist time it is called INCOMEPLETE
+    // Assuming it is the fist time it is called INCOMPLETE
     /**
      * Allows the organizer to draw n entrants from the waitlist.
      * @param n The number of entrants to sample.

--- a/bubbletracksapp/app/src/main/java/com/example/bubbletracksapp/OrganizerEntrantListActivity.java
+++ b/bubbletracksapp/app/src/main/java/com/example/bubbletracksapp/OrganizerEntrantListActivity.java
@@ -129,7 +129,6 @@ public class OrganizerEntrantListActivity extends AppCompatActivity
     @Override
     public boolean hasEntrantAccepted(Entrant entrant) {
         // Should check if entant accepted invitation
-        Log.d("TAG", enrolledList.toString());
         return enrolledList.contains(entrant);
     }
 

--- a/bubbletracksapp/app/src/main/java/com/example/bubbletracksapp/OrganizerEntrantListActivity.java
+++ b/bubbletracksapp/app/src/main/java/com/example/bubbletracksapp/OrganizerEntrantListActivity.java
@@ -32,10 +32,12 @@ public class OrganizerEntrantListActivity extends AppCompatActivity
     // invitedList contains all the entrants that are invited to the event
     // cancelledList contains all the entrants that were invited but rejected the invitation
     // rejectedList contains all the entrants that are not being invited to the event
+    // enrolledList contains all the entrants that were invited and accepted the invitation
     ArrayList<Entrant> waitList= new ArrayList<>();
     ArrayList<Entrant> invitedList= new ArrayList<>();
     ArrayList<Entrant> cancelledList = new ArrayList<>();
     ArrayList<Entrant> rejectedList = new ArrayList<>();
+    ArrayList<Entrant> enrolledList = new ArrayList<>();
     int maximumNumberOfEntrants;
     OrganizerEditActivity organizerEditActivity;
 
@@ -66,6 +68,9 @@ public class OrganizerEntrantListActivity extends AppCompatActivity
         if(in.getParcelableArrayListExtra("rejected") != null) {
             rejectedList.addAll(in.getParcelableArrayListExtra("rejected"));
         }
+        if(in.getParcelableArrayListExtra("enrolled") != null) {
+            enrolledList.addAll(in.getParcelableArrayListExtra("enrolled"));
+        }
         if(in.getParcelableArrayListExtra("cancelled") != null) {
             cancelledList.addAll(in.getParcelableArrayListExtra("cancelled"));
         }
@@ -90,6 +95,7 @@ public class OrganizerEntrantListActivity extends AppCompatActivity
                 intent.putParcelableArrayListExtra("invited", invitedList);
                 intent.putParcelableArrayListExtra("rejected", rejectedList);
                 intent.putParcelableArrayListExtra("cancelled", cancelledList);
+                intent.putParcelableArrayListExtra("enrolled", enrolledList);
 
                 startActivity(intent);
             }
@@ -118,6 +124,7 @@ public class OrganizerEntrantListActivity extends AppCompatActivity
         waitList.remove(entrant);
         invitedList.remove(entrant);
         rejectedList.remove(entrant);
+        enrolledList.remove(entrant);
         cancelledList.add(entrant);
         UpdateListDisplay();
     }
@@ -125,7 +132,8 @@ public class OrganizerEntrantListActivity extends AppCompatActivity
     @Override
     public boolean hasEntrantAccepted(Entrant entrant) {
         // Should check if entant accepted invitation
-        return false;
+        Log.d("TAG", enrolledList.toString());
+        return enrolledList.contains(entrant);
     }
 
 

--- a/bubbletracksapp/app/src/main/java/com/example/bubbletracksapp/OrganizerEntrantListActivity.java
+++ b/bubbletracksapp/app/src/main/java/com/example/bubbletracksapp/OrganizerEntrantListActivity.java
@@ -27,6 +27,7 @@ public class OrganizerEntrantListActivity extends AppCompatActivity
 
     private LotteryMainExtendBinding binding;
 
+    Event event;
     //To be changed to waitlist class INCOMPLETE
     // waitList contains all the entrants that joined the waitlist
     // invitedList contains all the entrants that are invited to the event
@@ -57,23 +58,18 @@ public class OrganizerEntrantListActivity extends AppCompatActivity
         binding = LotteryMainExtendBinding.inflate(getLayoutInflater());
         setContentView(binding.getRoot());
 
-        // INCOMPLETE
         Intent in =  getIntent();
-        if(in.getParcelableArrayListExtra("wait") != null) {
-            waitList.addAll(in.getParcelableArrayListExtra("wait"));
+        try {
+            event = in.getParcelableExtra("event");
+        } catch (Exception e) {
+            Log.d("OrganizerEntrantListActivity", "event extra was not passed correctly");
+            throw new RuntimeException(e);
         }
-        if(in.getParcelableArrayListExtra("invited") != null) {
-            invitedList.addAll(in.getParcelableArrayListExtra("invited"));
-        }
-        if(in.getParcelableArrayListExtra("rejected") != null) {
-            rejectedList.addAll(in.getParcelableArrayListExtra("rejected"));
-        }
-        if(in.getParcelableArrayListExtra("enrolled") != null) {
-            enrolledList.addAll(in.getParcelableArrayListExtra("enrolled"));
-        }
-        if(in.getParcelableArrayListExtra("cancelled") != null) {
-            cancelledList.addAll(in.getParcelableArrayListExtra("cancelled"));
-        }
+        waitList = event.getWaitList();
+        invitedList = event.getInvitedList();
+        rejectedList = event.getRejectedList();
+        cancelledList = event.getCancelledList();
+        enrolledList = event.getEnrolledList();
 
         waitlistListView = binding.waitlistView;
         waitlistAdapter = new EntrantListAdapter(this, waitList);
@@ -90,12 +86,13 @@ public class OrganizerEntrantListActivity extends AppCompatActivity
         binding.backButton.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
+                event.setWaitList(waitList);
+                event.setInvitedList(invitedList);
+                event.setRejectedList(rejectedList);
+                event.setCancelledList(cancelledList);
+                event.setEnrolledList(enrolledList);
                 Intent intent = new Intent(OrganizerEntrantListActivity.this, OrganizerEditActivity.class);
-                intent.putParcelableArrayListExtra("wait", waitList);
-                intent.putParcelableArrayListExtra("invited", invitedList);
-                intent.putParcelableArrayListExtra("rejected", rejectedList);
-                intent.putParcelableArrayListExtra("cancelled", cancelledList);
-                intent.putParcelableArrayListExtra("enrolled", enrolledList);
+                intent.putExtra("event", event);
 
                 startActivity(intent);
             }

--- a/bubbletracksapp/app/src/main/java/com/example/bubbletracksapp/OrganizerEntrantListActivity.java
+++ b/bubbletracksapp/app/src/main/java/com/example/bubbletracksapp/OrganizerEntrantListActivity.java
@@ -22,7 +22,8 @@ import java.util.Collections;
  * redraw them and replace them with someone from the waitlist.
  * @author Chester
  */
-public class OrganizerEntrantListActivity extends AppCompatActivity implements CancelledListAdapter.CancelledEntrantI {
+public class OrganizerEntrantListActivity extends AppCompatActivity
+        implements CancelledListAdapter.CancelledEntrantI, InvitedListAdapter.InvitedEntrantI {
 
     private LotteryMainExtendBinding binding;
 
@@ -46,12 +47,6 @@ public class OrganizerEntrantListActivity extends AppCompatActivity implements C
 
     ListView cancelledListView;
     CancelledListAdapter cancelledAdapter;
-
-
-    ArrayList<String> waitListArray = new ArrayList<>();
-    ArrayList<String> invitedListArray = new ArrayList<>();
-    ArrayList<String> cancelledListArray = new ArrayList<>();
-
 
     @Override
     public void onCreate(@Nullable Bundle savedInstanceState) {
@@ -86,7 +81,6 @@ public class OrganizerEntrantListActivity extends AppCompatActivity implements C
         cancelledListView = binding.cancelledListView;
         cancelledAdapter = new CancelledListAdapter(this, cancelledList);
         cancelledListView.setAdapter(cancelledAdapter);
-        Log.d("TAG", "onViewCreated: ");
 
         binding.backButton.setOnClickListener(new View.OnClickListener() {
             @Override
@@ -100,6 +94,7 @@ public class OrganizerEntrantListActivity extends AppCompatActivity implements C
                 startActivity(intent);
             }
         });
+
     }
 
 
@@ -118,14 +113,21 @@ public class OrganizerEntrantListActivity extends AppCompatActivity implements C
         return chosenEntrant;
     }
 
-    //Called when an Entrant cancels or rejects invitation and og clicks on it
-    public void cancelledEntrant(Entrant entrant){
-        invitedList.remove(entrant);
+    //Called when an Entrant cancels or rejects invitation and organize clicks on it
+    public void cancelEntrant(Entrant entrant) {
         waitList.remove(entrant);
+        invitedList.remove(entrant);
         rejectedList.remove(entrant);
         cancelledList.add(entrant);
         UpdateListDisplay();
     }
+
+    @Override
+    public boolean hasEntrantAccepted(Entrant entrant) {
+        // Should check if entant accepted invitation
+        return false;
+    }
+
 
     // should return error if the list is empty INCOMPLETE
     /**

--- a/bubbletracksapp/app/src/main/java/com/example/bubbletracksapp/OrganizerEventHosting.java
+++ b/bubbletracksapp/app/src/main/java/com/example/bubbletracksapp/OrganizerEventHosting.java
@@ -91,6 +91,7 @@ public class OrganizerEventHosting extends Fragment{
         en = new Entrant();
         en.setName("ches", " tata");
         e.addToWaitList(en);
+        e.addToEnrolledList(en);
 
         en = new Entrant();
         en.setName("zoe", " tata");

--- a/bubbletracksapp/app/src/main/res/layout/attendee_status_item.xml
+++ b/bubbletracksapp/app/src/main/res/layout/attendee_status_item.xml
@@ -1,21 +1,36 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:orientation="horizontal">
+
     <TextView
         android:id="@+id/attendee_name"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:layout_weight="0.45"
         android:padding="20dp"
-        android:textSize="20sp"
-        android:text="Attendee Name" />
+        android:text="Attendee Name"
+        android:textSize="20sp" />
+
     <TextView
         android:id="@+id/attendee_status"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:layout_weight="0.45"
         android:padding="20dp"
-        android:textSize="20sp"
-        android:text="Attendee status" />
+        android:text="Attendee status"
+        android:textColor="#048104"
+        android:textSize="20sp" />
+
+    <ImageButton
+        android:id="@+id/cancel_entrant_button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="10dp"
+        android:layout_weight="0.1"
+        android:background="@drawable/round_event"
+        app:srcCompat="@android:drawable/ic_menu_close_clear_cancel" />
 </LinearLayout>

--- a/bubbletracksapp/app/src/main/res/values/colors.xml
+++ b/bubbletracksapp/app/src/main/res/values/colors.xml
@@ -5,4 +5,6 @@
     <color name="home_blue">#2196F3</color>
     <color name="home">#F0F321</color>
     <color name="search">#99ACEC</color>
+    <color name="positive">#FF018104</color>
+    <color name="neutral">#9DA7AC</color>
 </resources>

--- a/bubbletracksapp/app/src/main/res/values/strings.xml
+++ b/bubbletracksapp/app/src/main/res/values/strings.xml
@@ -46,4 +46,6 @@
     <string name="search_hint">Search\n</string>
     <string name="join_waitlist">Join Waitlist</string>
     <string name="leave_waitlist">Leave Waitlist</string>
+    <string name="enrolledEntrantState">Enrolled</string>
+    <string name="notEnrolledEntrantState">Waiting</string>
 </resources>


### PR DESCRIPTION
Closes #31 and #30.
It allows organizers to cancel entrants and when they view the lists they can see the status of the invited entrants (ie whether they accepted the invitation or not)

To test it you can add:
```
        if (savedInstanceState == null) {
            getSupportFragmentManager().beginTransaction()
                    .setReorderingAllowed(true)
                    .add(R.id.content_holder, OrganizerEventHosting.class, null)
                    .commit();
        }

```

after:
`        Log.d("DeviceID:",currentDeviceID);
`
in MainActivity.