### PR TITLE
Geolocation map

### DIFF
--- a/bubbletracksapp/app/build.gradle.kts
+++ b/bubbletracksapp/app/build.gradle.kts
@@ -56,5 +56,6 @@ dependencies {
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.0.1")
     androidTestImplementation("androidx.test.espresso:espresso-contrib:3.4.0")
     implementation("com.github.rubensousa:gravitysnaphelper:2.2.2")
+    implementation("com.google.android.gms:play-services-location:19.9.1")
     implementation("com.google.android.gms:play-services-maps:19.0.0")
 }

--- a/bubbletracksapp/app/build.gradle.kts
+++ b/bubbletracksapp/app/build.gradle.kts
@@ -32,6 +32,7 @@ android {
     }
     buildFeatures {
         viewBinding = true
+        buildConfig = true
     }
 }
 
@@ -55,4 +56,5 @@ dependencies {
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.0.1")
     androidTestImplementation("androidx.test.espresso:espresso-contrib:3.4.0")
     implementation("com.github.rubensousa:gravitysnaphelper:2.2.2")
+    implementation("com.google.android.gms:play-services-maps:19.0.0")
 }

--- a/bubbletracksapp/app/src/main/AndroidManifest.xml
+++ b/bubbletracksapp/app/src/main/AndroidManifest.xml
@@ -2,6 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
     <uses-permission android:name="android.permission.CAMERA" />
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <uses-feature android:name="android.hardware.camera" />
     <uses-feature android:name="android.hardware.camera.autofocus" />
 

--- a/bubbletracksapp/app/src/main/AndroidManifest.xml
+++ b/bubbletracksapp/app/src/main/AndroidManifest.xml
@@ -71,6 +71,7 @@
         <activity android:name=".OrganizerActivity" />
         <activity android:name=".EntrantViewActivity" />
         <activity android:name=".AppUserEventScreenGenerator" />
+        <activity android:name=".OrganizerLocationsMap" />
     </application>
 
 </manifest>

--- a/bubbletracksapp/app/src/main/java/com/example/bubbletracksapp/Entrant.java
+++ b/bubbletracksapp/app/src/main/java/com/example/bubbletracksapp/Entrant.java
@@ -8,6 +8,7 @@ import android.os.Parcelable;
 
 import androidx.annotation.NonNull;
 
+import com.google.android.gms.maps.model.LatLng;
 import com.google.firebase.firestore.DocumentSnapshot;
 
 import java.util.ArrayList;
@@ -425,4 +426,12 @@ public class Entrant implements Parcelable {
      * @param event string of waitlist
      */
     public void deleteFromEventsWaitlist(String event){ this.eventsWaitlist.remove(event); }
+
+    public LatLng getLocationPoint() {
+        return new LatLng(-33.852, 151.211);
+    }
+
+    public String getAddress() {
+        return "My home 6873";
+    }
 }

--- a/bubbletracksapp/app/src/main/java/com/example/bubbletracksapp/Entrant.java
+++ b/bubbletracksapp/app/src/main/java/com/example/bubbletracksapp/Entrant.java
@@ -36,6 +36,7 @@ public class Entrant implements Parcelable {
     private String phone;
     private String deviceID;
     private Boolean notification;
+    private LatLng geolocation;
     private String role;
     private ArrayList<String> eventsOrganized = new ArrayList<>();
     private ArrayList<String> eventsInvited = new ArrayList<>();
@@ -50,17 +51,19 @@ public class Entrant implements Parcelable {
      * @param deviceID Entrants device ID to determine who the entrant is
      * @param notification Entrants declaration of allowing notification
      * @param role Denotes role; takes on either 'admin', 'organizer', or ''
+     * @param geolocation Denotes the geolocation when the entrant last updated their profile
      * @param eventsOrganized events from the organizer
-     * @param eventsInvited evened entrant is invited to
-     * @param eventsEnrolled event entrant is enrolled in
-     * @param eventsWaitlist event entrant is in waitlist for
+     * @param eventsInvited events entrant is invited to
+     * @param eventsEnrolled events entrant is enrolled in
+     * @param eventsWaitlist events entrant is in waitlist for
      */
-    public Entrant(String[] name, String email, String phone, String deviceID, Boolean notification, String role, ArrayList<String> eventsOrganized, ArrayList<String> eventsInvited, ArrayList<String> eventsEnrolled, ArrayList<String> eventsWaitlist) {
+    public Entrant(String[] name, String email, String phone, String deviceID, Boolean notification, LatLng geolocation, String role, ArrayList<String> eventsOrganized, ArrayList<String> eventsInvited, ArrayList<String> eventsEnrolled, ArrayList<String> eventsWaitlist) {
         this.name = name;
         this.email = email;
         this.phone = phone;
         this.deviceID = deviceID;
         this.notification = notification;
+        this.geolocation = geolocation;
         this.role = role;
         this.eventsOrganized = eventsOrganized;
         this.eventsInvited = eventsInvited;
@@ -79,6 +82,7 @@ public class Entrant implements Parcelable {
         this.deviceID = newDeviceID;
         this.role = "";
         this.notification = false;
+        this.geolocation = new LatLng(0,0);
         this.eventsOrganized = new ArrayList<>();
         this.eventsInvited = new ArrayList<>();
         this.eventsEnrolled = new ArrayList<>();
@@ -96,6 +100,7 @@ public class Entrant implements Parcelable {
         this.deviceID = "";
         this.role = "";
         this.notification = false;
+        this.geolocation = new LatLng(0,0);
         this.eventsOrganized = new ArrayList<>();
         this.eventsInvited = new ArrayList<>();
         this.eventsEnrolled = new ArrayList<>();
@@ -114,6 +119,9 @@ public class Entrant implements Parcelable {
         this.phone = document.getString("phone");
         this.deviceID = document.getString("ID");
         this.notification = document.getBoolean("notification");
+        double lat = document.getGeoPoint("geolocation").getLatitude();
+        double lng = document.getGeoPoint("geolocation").getLongitude();
+        this.geolocation = new LatLng(lat, lng);
         this.role = document.getString("role");
         this.eventsOrganized = (ArrayList<String>)document.getData().get("organized");
         this.eventsInvited = (ArrayList<String>)document.getData().get("invited");
@@ -134,6 +142,7 @@ public class Entrant implements Parcelable {
         deviceID = in.readString();
         byte tmpNotification = in.readByte();
         notification = tmpNotification == 0 ? null : tmpNotification == 1;
+        geolocation = in.readParcelable(LatLng.class.getClassLoader());
         role = in.readString();
         eventsOrganized = in.createStringArrayList();
         eventsInvited = in.createStringArrayList();
@@ -282,6 +291,7 @@ public class Entrant implements Parcelable {
         parcel.writeString(phone);
         parcel.writeString(deviceID);
         parcel.writeByte((byte) (notification == null ? 0 : notification ? 1 : 2));
+        parcel.writeParcelable(geolocation, i);
         parcel.writeString(role);
         parcel.writeStringList(eventsOrganized);
         parcel.writeStringList(eventsInvited);

--- a/bubbletracksapp/app/src/main/java/com/example/bubbletracksapp/Entrant.java
+++ b/bubbletracksapp/app/src/main/java/com/example/bubbletracksapp/Entrant.java
@@ -10,6 +10,7 @@ import androidx.annotation.NonNull;
 
 import com.google.android.gms.maps.model.LatLng;
 import com.google.firebase.firestore.DocumentSnapshot;
+import com.google.firebase.firestore.GeoPoint;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -119,9 +120,7 @@ public class Entrant implements Parcelable {
         this.phone = document.getString("phone");
         this.deviceID = document.getString("ID");
         this.notification = document.getBoolean("notification");
-        double lat = document.getGeoPoint("geolocation").getLatitude();
-        double lng = document.getGeoPoint("geolocation").getLongitude();
-        this.geolocation = new LatLng(lat, lng);
+        this.geolocation = geoPointToLatLng(document.getGeoPoint("geolocation"));
         this.role = document.getString("role");
         this.eventsOrganized = (ArrayList<String>)document.getData().get("organized");
         this.eventsInvited = (ArrayList<String>)document.getData().get("invited");
@@ -181,6 +180,7 @@ public class Entrant implements Parcelable {
         map.put("email", email);
         map.put("phone", phone);
         map.put("role", role);
+        map.put("geolocation", latLngToGeoPoint(geolocation));
         map.put("notification", notification);
         map.put("ID", deviceID);
         map.put("organized", eventsOrganized);
@@ -452,11 +452,45 @@ public class Entrant implements Parcelable {
      */
     public void deleteFromEventsWaitlist(String event){ this.eventsWaitlist.remove(event); }
 
-    public LatLng getLocationPoint() {
-        return new LatLng(-33.852, 151.211);
+
+    /**
+     * Get the geolocation coordinates
+     * @return The latitude and longitude of the entrant
+     */
+    public LatLng getGeolocation() {
+        return geolocation;
     }
 
-    public String getAddress() {
-        return "My home 6873";
+    /**
+     * Set the geolocation coordinates
+     * @param geolocation the geolocation point in latitude and longitude
+     */
+    public void setGeolocation(LatLng geolocation) {
+        this.geolocation = geolocation;
     }
+
+    /**
+     * Transforms a LatLng point to a geoPoint
+     * Used to store in database
+     * @param geolocation LatLng point to be transformed
+     * @return geoPoint from the given LatLng point
+     */
+    private GeoPoint latLngToGeoPoint(LatLng geolocation) {
+        double lat = geolocation.latitude;
+        double lng = geolocation.longitude;
+        return new GeoPoint(lat,lng);
+    }
+
+    /**
+     * Transforms a geoPoint to a LatLng point
+     * Used to get from database
+     * @param geolocation geoPoint point to be transformed
+     * @return LatLng point from the given geoPoint
+     */
+    private LatLng geoPointToLatLng(GeoPoint geolocation) {
+        double lat = geolocation.getLatitude();
+        double lng = geolocation.getLongitude();
+        return new LatLng(lat,lng);
+    }
+
 }

--- a/bubbletracksapp/app/src/main/java/com/example/bubbletracksapp/EntrantEditActivity.java
+++ b/bubbletracksapp/app/src/main/java/com/example/bubbletracksapp/EntrantEditActivity.java
@@ -51,8 +51,8 @@ public class EntrantEditActivity extends AppCompatActivity {
     private ActivityResultLauncher<String> requestPermissionLauncher;
     private ProfileManagementBinding binding;
     private Entrant currentUser;
-    EntrantDB db = new EntrantDB();
-    FusedLocationProviderClient fusedLocationProviderClient;
+    private EntrantDB db = new EntrantDB();
+    private FusedLocationProviderClient fusedLocationProviderClient;
 
     /**
      * Start up activity for entrant to edit their profile

--- a/bubbletracksapp/app/src/main/java/com/example/bubbletracksapp/EntrantViewActivity.java
+++ b/bubbletracksapp/app/src/main/java/com/example/bubbletracksapp/EntrantViewActivity.java
@@ -144,9 +144,15 @@ public class EntrantViewActivity extends AppCompatActivity {
     protected void addEntrant(){
         AlertDialog joinDialog;
         if (!inWaitlist) { // Entrant wants to join waitlist
+            String message = "";
+            if(event.getNeedsGeolocation()){
+                message = "This waitlist requires information about your current location. Are you sure you want to join the waitlist for this event?";
+            } else{
+                message = "Are you sure you want to join the waitlist for this event?";
+            }
             joinDialog = new AlertDialog.Builder(EntrantViewActivity.this)
                     .setTitle("Confirm Joining Waitlist")
-                    .setMessage("Are you sure you want to join the waitlist for this event?")
+                    .setMessage(message)
                     .setPositiveButton("Confirm", new DialogInterface.OnClickListener() {
                         @Override
                         public void onClick(DialogInterface dialogInterface, int i) {

--- a/bubbletracksapp/app/src/main/java/com/example/bubbletracksapp/EntrantViewActivity.java
+++ b/bubbletracksapp/app/src/main/java/com/example/bubbletracksapp/EntrantViewActivity.java
@@ -1,10 +1,12 @@
 package com.example.bubbletracksapp;
 
+import android.Manifest;
 import android.app.AlertDialog;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.SharedPreferences;
+import android.content.pm.PackageManager;
 import android.os.Bundle;
 import android.view.View;
 import android.widget.Button;
@@ -13,11 +15,14 @@ import android.widget.ImageView;
 import android.widget.TextView;
 import android.widget.Toast;
 import androidx.appcompat.app.AppCompatActivity;
+
+import com.google.android.gms.maps.model.LatLng;
 import com.squareup.picasso.Picasso;
 
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Date;
+import java.util.Objects;
 
 public class EntrantViewActivity extends AppCompatActivity {
 
@@ -66,7 +71,15 @@ public class EntrantViewActivity extends AppCompatActivity {
         joinButton.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
-                addEntrant();
+                // If the event needs a geolocation, make sure the entrant has a geolocation
+                if(!event.getNeedsGeolocation() || !Objects.equals(entrant.getGeolocation(), new LatLng(0, 0)))
+                {
+                    addEntrant();
+                }
+                else {
+                    Toast.makeText(EntrantViewActivity.this, "Allow geolocation and update your profile" +
+                            " to join this waitlist", Toast.LENGTH_LONG).show();
+                }
             }
         });
 

--- a/bubbletracksapp/app/src/main/java/com/example/bubbletracksapp/EntrantViewActivity.java
+++ b/bubbletracksapp/app/src/main/java/com/example/bubbletracksapp/EntrantViewActivity.java
@@ -159,7 +159,7 @@ public class EntrantViewActivity extends AppCompatActivity {
         if (!inWaitlist) { // Entrant wants to join waitlist
             String message = "";
             if(event.getNeedsGeolocation()){
-                message = "This waitlist requires information about your current location. Are you sure you want to join the waitlist for this event?";
+                message = "This waitlist will share information about your current location. Are you sure you want to join the waitlist for this event?";
             } else{
                 message = "Are you sure you want to join the waitlist for this event?";
             }

--- a/bubbletracksapp/app/src/main/java/com/example/bubbletracksapp/OrganizerEditActivity.java
+++ b/bubbletracksapp/app/src/main/java/com/example/bubbletracksapp/OrganizerEditActivity.java
@@ -121,6 +121,15 @@ public class OrganizerEditActivity extends AppCompatActivity {
             }
         });
 
+        binding.viewAttendeeMapButton.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                Intent intent = new Intent(OrganizerEditActivity.this, OrganizerLocationsMap.class);
+                intent.putExtra("event", event);
+                startActivity(intent);
+            }
+        });
+
     }
 
     // should return error if n is bigger than the size of waitlist INCOMPLETE

--- a/bubbletracksapp/app/src/main/java/com/example/bubbletracksapp/OrganizerEntrantListActivity.java
+++ b/bubbletracksapp/app/src/main/java/com/example/bubbletracksapp/OrganizerEntrantListActivity.java
@@ -124,7 +124,10 @@ public class OrganizerEntrantListActivity extends AppCompatActivity
         binding.viewAttendeeMapButton.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
-                UpdateListDisplay();
+                event.updateEventFirebase();
+                Intent intent = new Intent(OrganizerEntrantListActivity.this, OrganizerLocationsMap.class);
+                intent.putExtra("event", event);
+                startActivity(intent);
             }
         });
     }

--- a/bubbletracksapp/app/src/main/java/com/example/bubbletracksapp/OrganizerLocationsMap.java
+++ b/bubbletracksapp/app/src/main/java/com/example/bubbletracksapp/OrganizerLocationsMap.java
@@ -83,8 +83,8 @@ public class OrganizerLocationsMap extends AppCompatActivity implements OnMapRea
         double latitudeSum = 0;
         double longitudeSum = 0;
         for(Entrant entrant : entrantList) {
-            latitudeSum += entrant.getLocationPoint().latitude;
-            longitudeSum += entrant.getLocationPoint().longitude;
+            latitudeSum += entrant.getGeolocation().latitude;
+            longitudeSum += entrant.getGeolocation().longitude;
             createMarker(googleMap, entrant);
         }
         int n = entrantList.size();
@@ -102,13 +102,12 @@ public class OrganizerLocationsMap extends AppCompatActivity implements OnMapRea
      * @author Chester
      */
     public void createMarker(GoogleMap googleMap, Entrant entrant) {
-        LatLng markerPoint = entrant.getLocationPoint();
+        LatLng markerPoint = entrant.getGeolocation();
         String entrantName = entrant.getNameAsString();
-        String address = entrant.getAddress();
         googleMap.addMarker(new MarkerOptions()
                 .position(markerPoint)
                 .title(entrantName)
-                .snippet(address)
+                .snippet(String.format("Location (%f,%f)", markerPoint.latitude, markerPoint.longitude))
         );
     }
 }

--- a/bubbletracksapp/app/src/main/java/com/example/bubbletracksapp/OrganizerLocationsMap.java
+++ b/bubbletracksapp/app/src/main/java/com/example/bubbletracksapp/OrganizerLocationsMap.java
@@ -20,6 +20,10 @@ import com.google.android.gms.maps.model.MarkerOptions;
 
 import java.util.ArrayList;
 
+/**
+ * Creates a map with the locations of the entrants of the given event.
+ * @author Chester
+ */
 public class OrganizerLocationsMap extends AppCompatActivity implements OnMapReadyCallback {
     private LocationsMapBinding binding;
     private Context context;
@@ -66,6 +70,12 @@ public class OrganizerLocationsMap extends AppCompatActivity implements OnMapRea
         });
     }
 
+    /**
+     * This function will run when the map is created and will populate it with
+     * markers that show the geolocations of the entrants that joined.
+     * @param googleMap The google map that will be populated with the Entrant's locations.
+     * @author Chester
+     */
     @Override
     public void onMapReady(@NonNull GoogleMap googleMap) {
         entrantList.add(new Entrant());
@@ -82,6 +92,15 @@ public class OrganizerLocationsMap extends AppCompatActivity implements OnMapRea
         googleMap.moveCamera(CameraUpdateFactory.newLatLngZoom(centerPoint, 10));
     }
 
+    /**
+     * This method creates a marker in the given google map with the name of the
+     * given Entrant as it's title and the specific address of the Entrant
+     * as extra information.
+     *
+     * @param googleMap The Google Map where the marker will be created.
+     * @param entrant The Entrant from which the name and the address will be retrieved.
+     * @author Chester
+     */
     public void createMarker(GoogleMap googleMap, Entrant entrant) {
         LatLng markerPoint = entrant.getLocationPoint();
         String entrantName = entrant.getNameAsString();

--- a/bubbletracksapp/app/src/main/java/com/example/bubbletracksapp/OrganizerLocationsMap.java
+++ b/bubbletracksapp/app/src/main/java/com/example/bubbletracksapp/OrganizerLocationsMap.java
@@ -78,8 +78,6 @@ public class OrganizerLocationsMap extends AppCompatActivity implements OnMapRea
      */
     @Override
     public void onMapReady(@NonNull GoogleMap googleMap) {
-        entrantList.add(new Entrant());
-
         double latitudeSum = 0;
         double longitudeSum = 0;
         for(Entrant entrant : entrantList) {

--- a/bubbletracksapp/app/src/main/java/com/example/bubbletracksapp/OrganizerLocationsMap.java
+++ b/bubbletracksapp/app/src/main/java/com/example/bubbletracksapp/OrganizerLocationsMap.java
@@ -1,0 +1,95 @@
+package com.example.bubbletracksapp;
+
+import android.content.Context;
+import android.content.Intent;
+import android.os.Bundle;
+import android.util.Log;
+import android.view.View;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.appcompat.app.AppCompatActivity;
+
+import com.example.bubbletracksapp.databinding.LocationsMapBinding;
+import com.google.android.gms.maps.CameraUpdateFactory;
+import com.google.android.gms.maps.GoogleMap;
+import com.google.android.gms.maps.MapView;
+import com.google.android.gms.maps.OnMapReadyCallback;
+import com.google.android.gms.maps.model.LatLng;
+import com.google.android.gms.maps.model.MarkerOptions;
+
+import java.util.ArrayList;
+
+public class OrganizerLocationsMap extends AppCompatActivity implements OnMapReadyCallback {
+    private LocationsMapBinding binding;
+    private Context context;
+    private Event event;
+    private EntrantDB entrantDB;
+    private ArrayList<Entrant> entrantList = new ArrayList<>();
+    private  MapView mapView;
+
+    @Override
+    protected void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        binding = LocationsMapBinding.inflate(getLayoutInflater());
+        setContentView(binding.getRoot());
+        context = this;
+        Intent in =  getIntent();
+        try {
+            event = in.getParcelableExtra("event");
+        } catch (Exception e) {
+            Log.d("OrganizerLocationsMap", "event extra was not passed correctly");
+            throw new RuntimeException(e);
+        }
+
+        mapView = binding.entrantsMap;
+
+        entrantDB = new EntrantDB();
+        entrantDB.getEntrantList(event.getWaitList()).thenAccept(entrants -> {
+            if(entrants != null){
+                entrantList = entrants;
+                Log.d("setMap", "WaitList loaded");
+            } else {
+                Log.d("setMap", "No entrants in waitlist");
+            }
+            mapView.getMapAsync(this);
+            mapView.onCreate(savedInstanceState);
+        });
+
+        binding.backButton.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                Intent i = new Intent(context, MainActivity.class);
+                startActivity(i);
+            }
+        });
+    }
+
+    @Override
+    public void onMapReady(@NonNull GoogleMap googleMap) {
+        entrantList.add(new Entrant());
+
+        double latitudeSum = 0;
+        double longitudeSum = 0;
+        for(Entrant entrant : entrantList) {
+            latitudeSum += entrant.getLocationPoint().latitude;
+            longitudeSum += entrant.getLocationPoint().longitude;
+            createMarker(googleMap, entrant);
+        }
+        int n = entrantList.size();
+        LatLng centerPoint = new LatLng(latitudeSum/n,longitudeSum/n);
+        googleMap.moveCamera(CameraUpdateFactory.newLatLngZoom(centerPoint, 10));
+    }
+
+    public void createMarker(GoogleMap googleMap, Entrant entrant) {
+        LatLng markerPoint = entrant.getLocationPoint();
+        String entrantName = entrant.getNameAsString();
+        String address = entrant.getAddress();
+        googleMap.addMarker(new MarkerOptions()
+                .position(markerPoint)
+                .title(entrantName)
+                .snippet(address)
+        );
+    }
+}

--- a/bubbletracksapp/app/src/main/res/layout/locations_map.xml
+++ b/bubbletracksapp/app/src/main/res/layout/locations_map.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:padding="16dp">
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:gravity="center"
+            android:layout_marginTop="8dp">
+
+            <ImageButton
+                    android:id="@+id/back_button"
+                    android:layout_width="40dp"
+                    android:layout_height="40dp"
+                    android:background="@drawable/round_event"
+                    android:src="@drawable/baseline_arrow_back_24"
+                    android:layout_margin="8dp"/>
+
+            <TextView
+                android:id="@+id/rounded_textview"
+                android:layout_width="300dp"
+                android:layout_height="wrap_content"
+                android:layout_gravity="end"
+                android:background="@drawable/round_event"
+                android:backgroundTint="@color/home_blue"
+                android:gravity="center"
+                android:padding="8dp"
+                android:text="ATTENDEE MAP"
+                android:textColor="#FFFFFF"
+                android:textSize="34sp" />
+        </LinearLayout>
+
+
+        <TextView
+            android:id="@+id/waitListDescription"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:paddingVertical="8dp"
+            android:text="Locations of Users in Wait List"
+            android:textSize="40sp"
+            android:textStyle="bold" />
+
+        <com.google.android.gms.maps.MapView
+            android:id="@+id/entrants_map"
+            android:layout_width="match_parent"
+            android:layout_height="437dp" />
+
+    </LinearLayout>
+</ScrollView>

--- a/bubbletracksapp/app/src/main/res/layout/profile_management.xml
+++ b/bubbletracksapp/app/src/main/res/layout/profile_management.xml
@@ -66,13 +66,22 @@
             app:layout_constraintTop_toBottomOf="@+id/entrantPhoneInput" />
 
         <TextView
-            android:id="@+id/deviceIDNote"
+            android:id="@+id/locationNote"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="TextView"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/notificationToggle" />
+
+        <TextView
+            android:id="@+id/deviceIDNote"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="TextView"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/locationNote" />
 
         <Button
             android:id="@+id/profileUpdate"

--- a/bubbletracksapp/app/src/test/java/com/example/bubbletracksapp/EntrantTest.java
+++ b/bubbletracksapp/app/src/test/java/com/example/bubbletracksapp/EntrantTest.java
@@ -1,9 +1,13 @@
 package com.example.bubbletracksapp;
 
+import org.junit.Assert;
 import org.junit.Test;
 import static org.junit.jupiter.api.Assertions.*;
 
 import android.util.Log;
+
+import com.google.android.gms.maps.model.LatLng;
+import com.google.firebase.firestore.GeoPoint;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -18,6 +22,8 @@ public class EntrantTest {
         String phone = "8253302549";
         String deviceID = "TheID tested";
         Boolean notification = false;
+        LatLng geolocation = new LatLng(0,0);
+        String role = "";
         ArrayList<String> eventsOrganized = new ArrayList<>();
         eventsOrganized.add("Event1");
         eventsOrganized.add("Event2");
@@ -31,7 +37,7 @@ public class EntrantTest {
         eventsWaitlist.add("Event6");
         eventsWaitlist.add("Event7");
 
-        Entrant newEntrant = new Entrant(name, email, phone, deviceID, notification,
+        Entrant newEntrant = new Entrant(name, email, phone, deviceID, notification, geolocation, role,
                 eventsOrganized, eventsInvited, eventsEnrolled, eventsWaitlist);
         return newEntrant;
     }
@@ -54,6 +60,8 @@ public class EntrantTest {
         String phone = "8253302549";
         String deviceID = "TheID tested";
         Boolean notification = false;
+        LatLng geolocation = new LatLng(0,0);
+        String role = "";
         ArrayList<String> eventsOrganized = new ArrayList<>();
         eventsOrganized.add("Event1");
         eventsOrganized.add("Event2");
@@ -70,6 +78,10 @@ public class EntrantTest {
         assertEquals(map.get("name"), entrant.getNameAsList());
         assertEquals(map.get("email"), email);
         assertEquals(map.get("phone"), phone);
+        assertEquals(map.get("notification"), notification);
+        GeoPoint location = (GeoPoint) map.get("geolocation");
+        assertTrue(location.getClass() == GeoPoint.class);
+        assertEquals(new LatLng(location.getLatitude(), location.getLongitude()), geolocation);
         assertEquals(map.get("notification"), notification);
         assertEquals(map.get("ID"), deviceID);
         assertEquals(map.get("organized"), eventsOrganized);
@@ -373,5 +385,28 @@ public class EntrantTest {
     public void deleteFromEventsWaitlistTest() {
         entrant = mockEntrant();
 
+    }
+
+    /**
+     * Make new geolocation as the mock one.
+     * Make sure it is equal.
+     */
+    @Test
+    public void getGeolocation() {
+        entrant = mockEntrant();
+        Assert.assertEquals(entrant.getGeolocation(), new LatLng(0,0));
+    }
+
+    /**
+     * Make new geolocation.
+     * Set it in the mock entrant
+     * Make sure it is equal.
+     */
+    @Test
+    public void setGeolocation() {
+        entrant = mockEntrant();
+        LatLng sydneyLocation = new LatLng(-33.852,151.211);
+        entrant.setGeolocation(sydneyLocation);
+        Assert.assertEquals(entrant.getGeolocation(), new LatLng(-33.852,151.211));
     }
 }


### PR DESCRIPTION
Closes #21 and #44 .

- Users now have a field with their last known location.
- When they update their profile the location gets updated. (It does not get it when joining the waitlist, only when they last updated their profile)
- The location gets stored in the firebase.
- Lets users know whether joining a waitlist requires their geolocation.
- Does not allow users to join if they have not shared their geolocation.
- When the organizer clicks on view map of attendants in the lottery section, it opens a google map and loads the location of all the users in the waitlist.

To test:
There is no easy way to test it, you have to create a profile and update it to get the location.
Then create an event that requires geolocation and have some other users join. (In my case only I joined)
Go into hosted events waitlists and click the button.
