### PR TITLE
Bugfixes invitations and events

### DIFF
--- a/bubbletracksapp/app/src/main/AndroidManifest.xml
+++ b/bubbletracksapp/app/src/main/AndroidManifest.xml
@@ -38,31 +38,16 @@
         <activity android:name=".AdminProfileViews"
             android:exported="true"
             android:theme="@style/Theme.Bubbletracksapp">
-            <intent-filter>
-                <action android:name="android.intent.action.MAIN" />
-
-                <category android:name="android.intent.category.LAUNCHER" />
-            </intent-filter>
         </activity>
         <activity android:name=".AdminFacilityViews"
             android:exported="true"
             android:theme="@style/Theme.Bubbletracksapp">
-            <intent-filter>
-                <action android:name="android.intent.action.MAIN" />
-
-                <category android:name="android.intent.category.LAUNCHER" />
-            </intent-filter>
         </activity>
 
         <activity
             android:name=".QRScanner"
             android:exported="true"
             android:theme="@style/Theme.Bubbletracksapp">
-            <intent-filter>
-                <action android:name="android.intent.action.MAIN" />
-
-                <category android:name="android.intent.category.LAUNCHER" />
-            </intent-filter>
         </activity>
 
 
@@ -70,11 +55,6 @@
             android:name=".EntrantActivity"
             android:exported="true"
             android:theme="@style/Theme.Bubbletracksapp">
-            <intent-filter>
-                <action android:name="android.intent.action.MAIN" />
-
-                <category android:name="android.intent.category.LAUNCHER" />
-            </intent-filter>
         </activity>
 
         <activity android:name=".OrganizerEntrantListActivity"/>
@@ -83,11 +63,6 @@
             android:name=".EntrantEditActivity"
             android:exported="true"
             android:theme="@style/Theme.Bubbletracksapp">
-            <intent-filter>
-                <action android:name="android.intent.action.MAIN" />
-
-                <category android:name="android.intent.category.LAUNCHER" />
-            </intent-filter>
         </activity>
         <activity android:name=".OrganizerActivity" />
         <activity android:name=".OrganizerFacilityActivity" />

--- a/bubbletracksapp/app/src/main/java/com/example/bubbletracksapp/AppEventAdapter.java
+++ b/bubbletracksapp/app/src/main/java/com/example/bubbletracksapp/AppEventAdapter.java
@@ -27,10 +27,10 @@ import java.util.List;
 public class AppEventAdapter extends RecyclerView.Adapter<AppEventAdapter.EventViewHolder>{
 
     // ATTRIBUTES
-    Context context;
-    List<Event> eventList;
-    Entrant user;
-    Event event;
+    private Context context;
+    private List<Event> eventList;
+    private Entrant user;
+    private Event event;
 
     public AppEventAdapter (Context context, List<Event> eventList, Entrant user) {
         this.context = context;

--- a/bubbletracksapp/app/src/main/java/com/example/bubbletracksapp/AppEventAdapter.java
+++ b/bubbletracksapp/app/src/main/java/com/example/bubbletracksapp/AppEventAdapter.java
@@ -15,6 +15,8 @@ import androidx.annotation.NonNull;
 import androidx.core.content.ContextCompat;
 import androidx.recyclerview.widget.RecyclerView;
 
+import com.squareup.picasso.Picasso;
+
 import java.util.Date;
 import java.util.List;
 
@@ -29,13 +31,11 @@ public class AppEventAdapter extends RecyclerView.Adapter<AppEventAdapter.EventV
     List<Event> eventList;
     Entrant user;
     Event event;
-    Integer eventPicInteger;
 
-    public AppEventAdapter (Context context, List<Event> eventList, Entrant user, Integer eventPicInteger) {
+    public AppEventAdapter (Context context, List<Event> eventList, Entrant user) {
         this.context = context;
         this.eventList = eventList;
         this.user = user;
-        this.eventPicInteger = eventPicInteger;
     }
 
     public void setUser(Entrant user) {
@@ -146,7 +146,7 @@ public class AppEventAdapter extends RecyclerView.Adapter<AppEventAdapter.EventV
 
 
         // SETS EVENT IMAGE
-        holder.eventPic.setImageResource(R.drawable.default_image); // Replace with a default drawable
+        Picasso.get().load(event.getImage()).into(holder.eventPic);
 
 
         // DETERMINES EVENT DISPLAY SIZE

--- a/bubbletracksapp/app/src/main/java/com/example/bubbletracksapp/AppEventAdapter.java
+++ b/bubbletracksapp/app/src/main/java/com/example/bubbletracksapp/AppEventAdapter.java
@@ -1,6 +1,7 @@
 package com.example.bubbletracksapp;
 
 import android.content.Context;
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -14,6 +15,7 @@ import androidx.annotation.NonNull;
 import androidx.core.content.ContextCompat;
 import androidx.recyclerview.widget.RecyclerView;
 
+import java.util.Date;
 import java.util.List;
 
 
@@ -26,6 +28,7 @@ public class AppEventAdapter extends RecyclerView.Adapter<AppEventAdapter.EventV
     Context context;
     List<Event> eventList;
     Entrant user;
+    Event event;
     Integer eventPicInteger;
 
     public AppEventAdapter (Context context, List<Event> eventList, Entrant user, Integer eventPicInteger) {
@@ -33,6 +36,10 @@ public class AppEventAdapter extends RecyclerView.Adapter<AppEventAdapter.EventV
         this.eventList = eventList;
         this.user = user;
         this.eventPicInteger = eventPicInteger;
+    }
+
+    public void setUser(Entrant user) {
+        this.user = user;
     }
 
     // CONSTRUCTOR THAT MATCHES SUPER CLASS
@@ -50,8 +57,6 @@ public class AppEventAdapter extends RecyclerView.Adapter<AppEventAdapter.EventV
 
             eventTitle = itemView.findViewById(R.id.eventTitle);
             eventRegStatus = itemView.findViewById(R.id.eventRegStatus);
-            eventDateTime = itemView.findViewById(R.id.eventDateTime);
-            eventLocation = itemView.findViewById(R.id.eventLocation);
             eventPic = itemView.findViewById(R.id.eventPic);
             eventParent = itemView.findViewById(R.id.eventParent);
             accept = itemView.findViewById(R.id.accept);
@@ -95,7 +100,7 @@ public class AppEventAdapter extends RecyclerView.Adapter<AppEventAdapter.EventV
      */
     @Override
     public void onBindViewHolder(@NonNull EventViewHolder holder, int position) {
-        Event event = eventList.get(position);
+        event = eventList.get(position);
 
         // Set up the accept button with an OnClickListener, passing the event object
         holder.accept.setOnClickListener(v -> {
@@ -138,13 +143,6 @@ public class AppEventAdapter extends RecyclerView.Adapter<AppEventAdapter.EventV
             regStatus = "WAITLISTED";
         }
         holder.eventRegStatus.setText(regStatus != null ? regStatus : "unknown");
-
-
-        // SETS EVENT LOCATION
-        //holder.eventLocation.setText();
-
-        //SET EVENT TIME
-        //holder.eventDateTime.setText();
 
 
         // SETS EVENT IMAGE

--- a/bubbletracksapp/app/src/main/java/com/example/bubbletracksapp/AppEventAdapter.java
+++ b/bubbletracksapp/app/src/main/java/com/example/bubbletracksapp/AppEventAdapter.java
@@ -136,9 +136,9 @@ public class AppEventAdapter extends RecyclerView.Adapter<AppEventAdapter.EventV
         else if(user.getEventsWaitlist().contains(event.getId()) && user.getEventsWaitlist()!=null)
         {
             regStatus = "WAITLISTED";
-        } else {
-            holder.eventRegStatus.setText(regStatus != null ? regStatus : "unknown");
         }
+        holder.eventRegStatus.setText(regStatus != null ? regStatus : "unknown");
+
 
         // SETS EVENT LOCATION
         //holder.eventLocation.setText();

--- a/bubbletracksapp/app/src/main/java/com/example/bubbletracksapp/AppUserEventScreenGenerator.java
+++ b/bubbletracksapp/app/src/main/java/com/example/bubbletracksapp/AppUserEventScreenGenerator.java
@@ -165,7 +165,13 @@ public class AppUserEventScreenGenerator extends AppCompatActivity {
                         // Display a Toast or perform actions based on the selected item
                         Toast.makeText(AppUserEventScreenGenerator.this, "Selected: " + selectedOption, Toast.LENGTH_SHORT).show();
 
-                        displayList(currentUser);
+                        // Perform different actions based on selection
+                        if (selectedOption.equals("Waitlist")) {
+                            // Displays Waitlisted Event
+                            displayList("Waitlist");
+                        } else if (selectedOption.equals("Registered")) {
+                            displayList("Waitlist");
+                        }
                     }
 
                     @Override
@@ -202,22 +208,40 @@ public class AppUserEventScreenGenerator extends AppCompatActivity {
      * @param user
      *
      */
-    private void displayList(Entrant user) {
-        if (user == null) {
+    private void displayList(String type) {
+        if (currentUser == null) {
             // Log an error or handle the case when user is not yet available
             Log.e("AppUserEventScreen", "User object is null. Cannot display list.");
             return; // Exit the method early
         } else {
-            eventDB.getEventList(user.getEventsWaitlist()).thenAccept(events -> {
-                if(events != null) {
-                    eventList.clear();
-                    eventList.addAll(events);
-                    eventAdapter.notifyDataSetChanged();
-                }
-            });
+            if(Objects.equals(type, "Waitlist"))
+            {
+                setEventList(currentUser.getEventsWaitlist());
+            }
+            else if (Objects.equals(type, "Registered")) {
+                setEventList(currentUser.getEventsEnrolled());
+            }
         }
     }
 
+    /**
+     * Set the events of the adapter, depending if the user is looking at the events
+     * they are waiting to join or the events they enrolled.
+     * @param eventIDs The IDs of the events that will be set
+     */
+    private void setEventList(ArrayList<String> eventIDs) {
+        eventDB.getEventList(eventIDs).thenAccept(events -> {
+            if(events != null) {
+                eventAdapter.setEventList(events);
+                eventAdapter.notifyDataSetChanged();
+            }
+            else
+            {
+                eventList.clear();
+                eventAdapter.notifyDataSetChanged();
+            }
+        });
+    }
 
 
 }

--- a/bubbletracksapp/app/src/main/java/com/example/bubbletracksapp/AppUserEventScreenGenerator.java
+++ b/bubbletracksapp/app/src/main/java/com/example/bubbletracksapp/AppUserEventScreenGenerator.java
@@ -98,8 +98,8 @@ public class AppUserEventScreenGenerator extends AppCompatActivity {
         eventsplace.setHasFixedSize(true);
 
         // CREATE AND SET EVENT ADAPTER with the event list and the determined registration status
-        eventAdapter = new AppEventAdapter(AppUserEventScreenGenerator.this, eventList,
-                currentUser, null);
+        eventAdapter = new AppEventAdapter(AppUserEventScreenGenerator.this,
+                eventList, currentUser);
         eventsplace.setAdapter(eventAdapter);
 
         // Initialize a flag outside the listener to control the loop
@@ -212,7 +212,7 @@ public class AppUserEventScreenGenerator extends AppCompatActivity {
 
     }
 
-    
+
     /**
      * Displays list, whether it is the waitlist or enrolled list
      * @param type the type of list to be displayed

--- a/bubbletracksapp/app/src/main/java/com/example/bubbletracksapp/AppUserEventScreenGenerator.java
+++ b/bubbletracksapp/app/src/main/java/com/example/bubbletracksapp/AppUserEventScreenGenerator.java
@@ -90,6 +90,7 @@ public class AppUserEventScreenGenerator extends AppCompatActivity {
         // SETS UP TEXT VIEWS
         timeView = findViewById(R.id.eventDateTime);
         locationView = findViewById(R.id.eventLocation);
+        setDefaultActivityText();
 
         // SETS UP RECYCLER VIEW
         eventsplace = findViewById(R.id.waitlist);

--- a/bubbletracksapp/app/src/main/java/com/example/bubbletracksapp/AppUserEventScreenGenerator.java
+++ b/bubbletracksapp/app/src/main/java/com/example/bubbletracksapp/AppUserEventScreenGenerator.java
@@ -43,14 +43,10 @@ public class AppUserEventScreenGenerator extends AppCompatActivity {
 
     private RecyclerView eventsplace;
     private AppEventAdapter eventAdapter;
-    private List<Event> waitlistEvents = new ArrayList<>();
-    private List<Event> registeredEvents = new ArrayList<>();
-    private Button accept, decline;
     private TextView locationView, timeView;
     private ImageButton backButton;
     EntrantDB entrantDB = new EntrantDB();
     EventDB eventDB = new EventDB();
-    private List<String> otherOption = Arrays.asList("Waitlist", "Registered");
     private Spinner statusSpinner;
     private Entrant currentUser;
     List<Event> eventList = new ArrayList<>();
@@ -281,7 +277,7 @@ public class AppUserEventScreenGenerator extends AppCompatActivity {
      * Empty the text views of time and location.
      * It is used when no event is being displayed
      */
-    public void setDefaultActivityText() {
+    private void setDefaultActivityText() {
         timeView.setText(" ");
         locationView.setText(" ");
     }

--- a/bubbletracksapp/app/src/main/java/com/example/bubbletracksapp/AppUserEventScreenGenerator.java
+++ b/bubbletracksapp/app/src/main/java/com/example/bubbletracksapp/AppUserEventScreenGenerator.java
@@ -1,7 +1,9 @@
 package com.example.bubbletracksapp;
 
 import android.content.Context;
+import android.content.Intent;
 import android.content.SharedPreferences;
+import android.media.Image;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
@@ -12,6 +14,7 @@ import android.view.animation.AccelerateInterpolator;
 import android.widget.AdapterView;
 import android.widget.ArrayAdapter;
 import android.widget.Button;
+import android.widget.ImageButton;
 import android.widget.LinearLayout;
 import android.widget.Spinner;
 import android.widget.Toast;
@@ -41,6 +44,7 @@ public class AppUserEventScreenGenerator extends AppCompatActivity {
     private List<Event> waitlistEvents = new ArrayList<>();
     private List<Event> registeredEvents = new ArrayList<>();
     private Button accept, decline;
+    private ImageButton backButton;
     EntrantDB entrantDB = new EntrantDB();
     EventDB eventDB = new EventDB();
     private List<String> otherOption = Arrays.asList("Waitlist", "Registered");
@@ -169,6 +173,20 @@ public class AppUserEventScreenGenerator extends AppCompatActivity {
 
                     }
                 });
+
+                // INITIALIZE BUTTON TO GO BACK TO HOME SCREEN
+                backButton = findViewById(R.id.back_button);
+
+                // IMPLEMENTED BUTTON TO GO BACK TO HOME SCREEN
+                backButton.setOnClickListener(new View.OnClickListener() {
+                    @Override
+                    public void onClick(View view) {
+                        Intent intent = new Intent(AppUserEventScreenGenerator.this, MainActivity.class);
+                        intent.putExtra("user", currentUser);
+                        startActivity(intent);
+                    }
+                });
+
             }
         }).exceptionally(e -> {
             Toast.makeText(AppUserEventScreenGenerator.this, "Failed to load profile: " + e.getMessage(), Toast.LENGTH_LONG).show(); //also a fail
@@ -195,7 +213,6 @@ public class AppUserEventScreenGenerator extends AppCompatActivity {
                     eventList.clear();
                     eventList.addAll(events);
                     eventAdapter.notifyDataSetChanged();
-                    Log.d("TAG", "displayList: ");
                 }
             });
         }

--- a/bubbletracksapp/app/src/main/java/com/example/bubbletracksapp/EntrantEditActivity.java
+++ b/bubbletracksapp/app/src/main/java/com/example/bubbletracksapp/EntrantEditActivity.java
@@ -16,6 +16,7 @@ import android.widget.TextView;
 
 import androidx.activity.result.ActivityResultLauncher;
 import androidx.activity.result.contract.ActivityResultContracts;
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.RequiresApi;
 import androidx.appcompat.app.AppCompatActivity;
@@ -53,6 +54,16 @@ public class EntrantEditActivity extends AppCompatActivity {
     private Entrant currentUser;
     private EntrantDB db = new EntrantDB();
     private FusedLocationProviderClient fusedLocationProviderClient;
+    private String ID;
+    // Initialize fields
+    private EditText entrantNameInput;
+    private EditText entrantEmailInput;
+    private EditText entrantPhoneInput;
+    private CheckBox entrantNotificationInput;
+
+    // Initialize views
+    private TextView deviceIDNote;
+    private TextView locationNote;
 
     /**
      * Start up activity for entrant to edit their profile
@@ -87,16 +98,16 @@ public class EntrantEditActivity extends AppCompatActivity {
         fusedLocationProviderClient = LocationServices.getFusedLocationProviderClient(this);
 
 
-        EditText entrantNameInput = binding.entrantNameInput;
-        EditText entrantEmailInput = binding.entrantEmailInput;
-        EditText entrantPhoneInput = binding.entrantPhoneInput;
-        CheckBox entrantNotificationInput = binding.notificationToggle;
+        entrantNameInput = binding.entrantNameInput;
+        entrantEmailInput = binding.entrantEmailInput;
+        entrantPhoneInput = binding.entrantPhoneInput;
+        entrantNotificationInput = binding.notificationToggle;
 
-        TextView deviceIDNote = binding.deviceIDNote;
-        TextView locationNote = binding.locationNote;
+        deviceIDNote = binding.deviceIDNote;
+        locationNote = binding.locationNote;
 
         SharedPreferences localID = getSharedPreferences("LocalID", Context.MODE_PRIVATE);
-        String ID = localID.getString("ID", "Device ID not found");
+        ID = localID.getString("ID", "Device ID not found");
         String tempLocation = "No last location found. Allow location and update your profile";
 
         // Displays the user's profile

--- a/bubbletracksapp/app/src/main/java/com/example/bubbletracksapp/EntrantEditActivity.java
+++ b/bubbletracksapp/app/src/main/java/com/example/bubbletracksapp/EntrantEditActivity.java
@@ -1,7 +1,6 @@
 package com.example.bubbletracksapp;
 
 import android.content.Context;
-import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.pm.PackageManager;
 import android.location.Location;
@@ -14,31 +13,25 @@ import android.widget.CheckBox;
 import android.widget.EditText;
 import android.widget.TextView;
 
+import androidx.activity.result.ActivityResultCallback;
 import androidx.activity.result.ActivityResultLauncher;
 import androidx.activity.result.contract.ActivityResultContracts;
-import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.RequiresApi;
 import androidx.appcompat.app.AppCompatActivity;
-import androidx.core.app.NotificationManagerCompat;
 
-import com.example.bubbletracksapp.databinding.FragmentFirstBinding;
 import com.example.bubbletracksapp.databinding.ProfileManagementBinding;
 import com.google.android.gms.location.FusedLocationProviderClient;
 import com.google.android.gms.location.LocationServices;
 import com.google.android.gms.location.Priority;
 import com.google.android.gms.maps.model.LatLng;
 import com.google.android.gms.tasks.CancellationTokenSource;
-import com.google.android.gms.tasks.OnCompleteListener;
 import com.google.android.gms.tasks.OnSuccessListener;
 
 import android.Manifest; // For importing notification permissions
 import android.widget.Toast;
 
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
-
-import java.util.ArrayList;
+import java.util.Map;
 
 /**
  * This class allows an entrant to update their profile information.
@@ -49,7 +42,7 @@ import java.util.ArrayList;
  */
 public class EntrantEditActivity extends AppCompatActivity {
 
-    private ActivityResultLauncher<String> requestPermissionLauncher;
+    private ActivityResultLauncher<String[]> requestPermissionLauncher;
     private ProfileManagementBinding binding;
     private Entrant currentUser;
     private EntrantDB db = new EntrantDB();
@@ -84,14 +77,23 @@ public class EntrantEditActivity extends AppCompatActivity {
         Launcher to request permission from Entrant
          */
         requestPermissionLauncher = registerForActivityResult(
-                new ActivityResultContracts.RequestPermission(),
-                isGranted -> {
-                    if (isGranted) {
-                        // Permission granted
-                        Log.d("Notification check", "Notif permission granted");
-                    } else {
-                        // Permission denied
-                        Log.d("Notification check", "Notif permission denied");
+                new ActivityResultContracts.RequestMultiplePermissions(), new ActivityResultCallback<Map<String, Boolean>>() {
+                    @Override
+                    public void onActivityResult(Map<String, Boolean> o) {
+                        if (Boolean.TRUE.equals(o.get(Manifest.permission.POST_NOTIFICATIONS))) {
+                            // Permission granted
+                            Log.d("Notification check", "Notif permission granted");
+                        } else {
+                            // Permission denied
+                            Log.d("Notification check", "Notif permission denied");
+                        }
+                        if (Boolean.TRUE.equals(o.get(Manifest.permission.ACCESS_COARSE_LOCATION))) {
+                            // Permission granted
+                            Log.d("Geolocation check", "Geolocation permission granted");
+                        } else {
+                            // Permission denied
+                            Log.d("Geolocation check", "Geolocation permission denied");
+                        }
                     }
                 }
         );
@@ -156,7 +158,6 @@ public class EntrantEditActivity extends AppCompatActivity {
              */
             @Override
             public void onClick(View view) {
-                checkNotificationPermission(currentUser);
 
                 String[] newFullName = {"",""};
                 newFullName = entrantNameInput.getText().toString().split(" ");
@@ -180,40 +181,41 @@ public class EntrantEditActivity extends AppCompatActivity {
                         }
                         else {
                             checkNotificationPermission(currentUser);
-
                         }
-                        checkGeolocationPermission(currentUser);
 
                         // Gets the coarse location of the person and updates it.
                         // If it cant find it, it does not update the location.
                         CancellationTokenSource cancellationTokenSource = new CancellationTokenSource();
-                        fusedLocationProviderClient.getCurrentLocation(Priority.PRIORITY_HIGH_ACCURACY, cancellationTokenSource.getToken())
-                                .addOnSuccessListener(new OnSuccessListener<Location>() {
-                                    @Override
-                                    public void onSuccess(Location location) {
-                                        if (location != null) {
-                                            // Update the user's location
-                                            double lat = location.getLatitude();
-                                            double lng = location.getLongitude();
-                                            LatLng newGeolocation = new LatLng(lat, lng);
-                                            currentUser.setGeolocation(newGeolocation);
+                        if (checkSelfPermission(Manifest.permission.ACCESS_COARSE_LOCATION) == PackageManager.PERMISSION_GRANTED) {
+                            fusedLocationProviderClient.getCurrentLocation(Priority.PRIORITY_HIGH_ACCURACY, cancellationTokenSource.getToken())
+                                    .addOnSuccessListener(new OnSuccessListener<Location>() {
+                                        @Override
+                                        public void onSuccess(Location location) {
+                                            if (location != null) {
+                                                // Update the user's location
+                                                double lat = location.getLatitude();
+                                                double lng = location.getLongitude();
+                                                LatLng newGeolocation = new LatLng(lat, lng);
+                                                currentUser.setGeolocation(newGeolocation);
 
-                                            // Update the location node
-                                            String stringLocation = String.format("Your last location: (%f,%f)", lat, lng);
-                                            locationNote.setText(stringLocation);
+                                                // Update the location node
+                                                String stringLocation = String.format("Your last location: (%f,%f)", lat, lng);
+                                                locationNote.setText(stringLocation);
 
-                                            db.updateEntrant(currentUser);
-                                            Log.d("getCurrentLocation", newGeolocation.toString());
+                                                db.updateEntrant(currentUser);
+                                                Log.d("getCurrentLocation", newGeolocation.toString());
+                                            }
+                                            else
+                                            {
+                                                db.updateEntrant(currentUser);
+
+                                                Log.w("EntrantEditActivity", "No location could be found. Location was not updated");
+                                            }
+                                            Log.d("New user name:", currentUser.getNameAsString());
                                         }
-                                        else
-                                        {
-                                            db.updateEntrant(currentUser);
+                                    });
 
-                                            Log.w("EntrantEditActivity", "No location could be found. Location was not updated");
-                                        }
-                                        Log.d("New user name:", currentUser.getNameAsString());
-                                    }
-                                });
+                        }
                     } else {
                         Log.d("User not found", "");
                     }
@@ -224,6 +226,7 @@ public class EntrantEditActivity extends AppCompatActivity {
                 });
             }
         });
+        checkPermissions();
     }
 
     /**
@@ -237,22 +240,27 @@ public class EntrantEditActivity extends AppCompatActivity {
                 currentUser.setNotification(true);
                 Log.d("Notification check","Notification permission done");
             } else {
-                requestPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS);
+                currentUser.setNotification(false);
             }
         }
     }
 
     /**
-     * Launcher to ask user for geolocation permission
-     * @param currentUser entrant updating their profile
+     * Launcher to ask user for notification permission for posts and location
      */
-    private void checkGeolocationPermission(Entrant currentUser) {
+    private void checkPermissions() {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-            // Check if the geolocation permission is granted
-            if (checkSelfPermission(Manifest.permission.ACCESS_COARSE_LOCATION) == PackageManager.PERMISSION_GRANTED) {
-                Log.d("Geolocation check","Geolocation permission done");
-            } else {
-                requestPermissionLauncher.launch(Manifest.permission.ACCESS_COARSE_LOCATION);
+            String[] permissions = {Manifest.permission.POST_NOTIFICATIONS, Manifest.permission.ACCESS_COARSE_LOCATION};
+            // Check if both the notification permissions are granted
+            if (checkSelfPermission(Manifest.permission.POST_NOTIFICATIONS) == PackageManager.PERMISSION_GRANTED) {
+                Log.d("Notification check","Notification permission done");
+            }
+            if (checkSelfPermission(Manifest.permission.POST_NOTIFICATIONS) == PackageManager.PERMISSION_GRANTED &&
+                    checkSelfPermission(Manifest.permission.ACCESS_COARSE_LOCATION) == PackageManager.PERMISSION_GRANTED) {
+                Log.d("Permissions check","Both permissions done");
+            }
+            else {
+                requestPermissionLauncher.launch(permissions);
             }
         }
     }

--- a/bubbletracksapp/app/src/main/java/com/example/bubbletracksapp/EntrantViewActivity.java
+++ b/bubbletracksapp/app/src/main/java/com/example/bubbletracksapp/EntrantViewActivity.java
@@ -42,6 +42,9 @@ public class EntrantViewActivity extends AppCompatActivity {
     private Button joinButton;
     private ImageButton backButton;
 
+    // declare dialog that will appear when joining/leaving a waitlist
+    private boolean showsDialog;
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -71,6 +74,9 @@ public class EntrantViewActivity extends AppCompatActivity {
         joinButton.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
+                // Make sure that the dialog shows up only once
+                if (showsDialog) return;
+
                 // If the event needs a geolocation, make sure the entrant has a geolocation
                 if(!event.getNeedsGeolocation() || !Objects.equals(entrant.getGeolocation(), new LatLng(0, 0)))
                 {
@@ -156,6 +162,7 @@ public class EntrantViewActivity extends AppCompatActivity {
 
     protected void addEntrant(){
         AlertDialog joinDialog;
+        showsDialog = true;
         if (!inWaitlist) { // Entrant wants to join waitlist
             String message = "";
             if(event.getNeedsGeolocation()){
@@ -203,6 +210,12 @@ public class EntrantViewActivity extends AppCompatActivity {
                             dialogInterface.dismiss();
                         }
                     })
+                    .setOnDismissListener(new DialogInterface.OnDismissListener() {
+                        @Override
+                        public void onDismiss(DialogInterface dialogInterface) {
+                            showsDialog = false;
+                        }
+                    })
                     .create();
         }
         else { // Entrant wants to leave waitlist
@@ -227,6 +240,12 @@ public class EntrantViewActivity extends AppCompatActivity {
                         @Override
                         public void onClick(DialogInterface dialogInterface, int i) {
                             dialogInterface.dismiss();
+                        }
+                    })
+                    .setOnDismissListener(new DialogInterface.OnDismissListener() {
+                        @Override
+                        public void onDismiss(DialogInterface dialogInterface) {
+                            showsDialog = false;
                         }
                     })
                     .create();

--- a/bubbletracksapp/app/src/main/res/layout/event_lists.xml
+++ b/bubbletracksapp/app/src/main/res/layout/event_lists.xml
@@ -9,6 +9,40 @@
     tools:context=".MainActivity">
 
 
+    <LinearLayout
+        android:id="@+id/linearLayout2"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center"
+        android:orientation="horizontal"
+        android:padding="20dp">
+
+        <!--image button to go back to home screen-->
+        <ImageButton
+            android:id="@+id/back_button"
+            android:layout_width="40dp"
+            android:layout_height="40dp"
+            android:layout_margin="16dp"
+            android:background="@drawable/round_event"
+            android:backgroundTint="@color/home_blue"
+            android:src="@drawable/baseline_arrow_back_24" />
+
+        <!--text view for the title of the page-->
+        <TextView
+            android:id="@+id/rounded_textview"
+            android:layout_width="300dp"
+            android:layout_height="wrap_content"
+            android:background="@drawable/round_event"
+            android:backgroundTint="@color/home_blue"
+            android:gravity="center"
+            android:padding="16dp"
+            android:paddingBottom="16dp"
+            android:text="YOUR EVENTS"
+            android:textColor="#FFFFFF"
+            android:textSize="34sp" />
+
+    </LinearLayout>
+
     <Spinner
         android:id="@+id/listOptions"
         android:layout_width="wrap_content"
@@ -27,7 +61,7 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintHorizontal_bias="0.108"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/linearLayout2"
         app:layout_constraintVertical_bias="0.046"
         tools:ignore="MissingConstraints" />
 

--- a/bubbletracksapp/app/src/main/res/layout/item_event.xml
+++ b/bubbletracksapp/app/src/main/res/layout/item_event.xml
@@ -2,6 +2,7 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
 
+    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/eventParent"
     android:orientation="vertical"
     android:scaleX="0.9"
@@ -46,53 +47,58 @@
 
     <!-- ACCESSIBILITY ERROR-->
     <LinearLayout
-        android:orientation ="horizontal"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content">
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal">
 
         <TextView
             android:id="@+id/eventRegStatus"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:layout_marginStart="10dp"
             android:layout_marginTop="12dp"
-            android:layout_marginStart="16dp"
+            android:layout_marginEnd="5dp"
             android:layout_marginBottom="10dp"
-            android:padding = "8dp"
-            android:text = "INVITED"
+            android:layout_weight="0"
+            android:background="@drawable/statusitem_custom"
+            android:padding="8dp"
+            android:text="INVITED"
             android:textColor="#FFB95A"
-            android:textSize = "14sp"
-            android:textStyle="bold"
-            android:background = "@drawable/statusitem_custom"/>
+            android:textSize="14sp"
+            android:textStyle="bold" />
 
 
         <Button
             android:id="@+id/accept"
-            android:layout_width="50dp"
+            android:layout_width="wrap_content"
             android:layout_height="40dp"
+            android:layout_marginStart="5dp"
             android:layout_marginTop="12dp"
-            android:layout_marginStart="16dp"
+            android:layout_marginEnd="5dp"
             android:layout_marginBottom="10dp"
-            android:padding = "8dp"
-            android:backgroundTint = "#A4D4AE"
-            android:text = "Accept!"
-            android:textSize = "10sp"
-            android:visibility="gone" >
-        </Button>
+            android:layout_weight="1"
+            android:backgroundTint="#A4D4AE"
+            android:padding="0dp"
+            android:text="Accept!"
+            android:textSize="10sp"
+            android:visibility="gone"
+            tools:visibility="visible"></Button>
 
         <Button
             android:id="@+id/decline"
-            android:layout_width="50dp"
+            android:layout_width="wrap_content"
             android:layout_height="40dp"
+            android:layout_marginStart="5dp"
             android:layout_marginTop="12dp"
-            android:layout_marginStart="16dp"
+            android:layout_marginEnd="10dp"
             android:layout_marginBottom="10dp"
-            android:padding = "8dp"
-            android:backgroundTint = "#E57373"
-            android:text = "Decline"
-            android:textSize = "10sp"
-            android:visibility="gone" >
-        </Button>
-
+            android:layout_weight="1"
+            android:backgroundTint="#E57373"
+            android:padding="0dp"
+            android:text="Decline"
+            android:textSize="10sp"
+            android:visibility="gone"
+            tools:visibility="visible"></Button>
 
 
     </LinearLayout>

--- a/bubbletracksapp/app/src/main/res/layout/profile_management.xml
+++ b/bubbletracksapp/app/src/main/res/layout/profile_management.xml
@@ -60,7 +60,7 @@
             android:id="@+id/notificationToggle"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="Do not allow notifications from app or event organizers"
+            android:text="Allow notifications from app or event organizers"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/entrantPhoneInput" />


### PR DESCRIPTION
Bugfixing and polishing:
- The "Your events" screen now displays all the information correctly, including pictures, dates, accept/decline buttons and status.
- The creation of events no longer asks for permission and stops you from clicking the update button. Now it asks you as soon as you open that activity.
- Corrected the xml file in the profile creation text to explain that checking the notifications section WILL allow notifications.
- Fixed bug where an user was able to join/leave a waitlist twice by clicking the button twice.

