### PR TITLE
Organizer custom notification message

### DIFF
--- a/bubbletracksapp/app/src/main/java/com/example/bubbletracksapp/OrganizerEntrantListActivity.java
+++ b/bubbletracksapp/app/src/main/java/com/example/bubbletracksapp/OrganizerEntrantListActivity.java
@@ -251,7 +251,6 @@ public class OrganizerEntrantListActivity extends AppCompatActivity
             return;
         }
 
-        //TODO: ADD NEW ARRAY TO ADD
         invitedList.add(chosenEntrant);
         newInvitedList.add(String.valueOf(chosenEntrant));
         UpdateListDisplay();

--- a/bubbletracksapp/app/src/main/java/com/example/bubbletracksapp/OrganizerNotificationActivity.java
+++ b/bubbletracksapp/app/src/main/java/com/example/bubbletracksapp/OrganizerNotificationActivity.java
@@ -6,11 +6,14 @@ import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.os.Build;
 import android.os.Bundle;
+import android.text.TextUtils;
 import android.util.Log;
 import android.view.View;
 import android.widget.Button;
 import android.widget.CheckBox;
+import android.widget.EditText;
 import android.widget.ImageButton;
+import android.widget.TextView;
 import android.widget.Toast;
 
 import androidx.activity.result.ActivityResultLauncher;
@@ -33,9 +36,11 @@ import java.util.UUID;
 public class OrganizerNotificationActivity extends AppCompatActivity {
 
     private NotificationMainBinding binding;
-    Event event;
+    private Event event;
 
     NotificationDB db = new NotificationDB();
+    //private TextView notifTitle, smallText, bigText;
+
 
 
     /**
@@ -64,14 +69,24 @@ public class OrganizerNotificationActivity extends AppCompatActivity {
         CheckBox checkWaitlist = findViewById(R.id.checkbox_notify_waitlist);
         CheckBox checkConfirmed = findViewById(R.id.checkbox_notify_confirmed_attendees);
         CheckBox checkCancelled = findViewById(R.id.checkbox_notify_cancelled);
-        Button notifButton = findViewById(R.id.button_confirm);
-        notifButton.setOnClickListener(view -> sendNotification(checkInvited, checkWaitlist, checkConfirmed, checkCancelled));
+
+        ArrayList<CheckBox> entrantsChecks = new ArrayList<>();
+        entrantsChecks.add(checkInvited);
+        entrantsChecks.add(checkWaitlist);
+        entrantsChecks.add(checkConfirmed);
+        entrantsChecks.add(checkCancelled);
+
+        EditText notifTitleInput = binding.notifTitle;
+        EditText smallTextInput = binding.notifSmallText;
+        EditText bigTextInput = binding.notifBigText;
+
+
 
         binding.backButton.setOnClickListener(new View.OnClickListener()
 
         {
             /**
-             * set details of event lists
+             * go back to event hosting screen
              * @param view The view that was clicked.
              */
             @Override
@@ -80,105 +95,175 @@ public class OrganizerNotificationActivity extends AppCompatActivity {
                 startActivity(intent);
             }
         });
+
+        binding.defaultNotifButton.setOnClickListener(new View.OnClickListener() {
+            /**
+             * Sends notification after organizer confirms notification send
+             *
+             * @param view The view that was clicked.
+             */
+            @Override
+            public void onClick(View view) {
+                sendDefaultNotification(checkInvited, checkWaitlist, checkConfirmed, checkCancelled);
+            }
+
+            /**
+             * Organizer sends a default notification based on the type of entrant they selected to send to
+             *
+             * @param checkInvited   entrants invited to event
+             * @param checkWaitlist  entrants in waitlist for event
+             * @param checkConfirmed entrants who confirmed registration for event
+             * @param checkCancelled entrants who cancelled invitation to event
+             */
+            private void sendDefaultNotification(CheckBox checkInvited, CheckBox checkWaitlist, CheckBox checkConfirmed, CheckBox checkCancelled) {
+                if (!checkInvited.isChecked() && !checkWaitlist.isChecked() && !checkConfirmed.isChecked() && !checkCancelled.isChecked()) {
+                    Toast.makeText(OrganizerNotificationActivity.this, "Please select the entrant(s) you want to send a notification to!", Toast.LENGTH_LONG).show();
+                    return;
+                }
+                Date timestamp = new Date();
+                // Send to invited entrants
+                if (checkInvited.isChecked()) {
+                    Log.d("Notification(invited)", "This is invited action: ");
+                    ArrayList<String> invitedList = event.getInvitedList();
+                    if (invitedList != null) {
+                        Notifications notification = new Notifications(
+                                invitedList,
+                                "You Are Invited!",
+                                "Congratulations, you are invited to the event" + event.getName() + "!",
+                                "Accept your invitation to confirm your registration.",
+                                //"Thank you for confirming your attendance to " + event.getName() + "!"
+                                UUID.randomUUID().toString(),
+                                timestamp
+                        );
+                        db.addNotification(notification);
+                    } else {
+                        Toast.makeText(OrganizerNotificationActivity.this, "There are no invited entrants in your event!", Toast.LENGTH_LONG).show();
+                    }
+                }
+                // send wait list entrants
+                if (checkWaitlist.isChecked()) {
+                    Log.d("Notification(waitlist)", "This is waitlist action: ");
+                    //Log.d("Notification(waitlist)", "Event object: " + event);
+                    //entrantDB.getEntrantList(event.getWaitList()).thenAccept(entrants -> {
+                    ArrayList<String> invitedList = event.getWaitList();
+                    Log.d("Notification(waitlist)", "Event object: " + event.getWaitList());
+                    if (invitedList != null) {
+                        Notifications notification = new Notifications(
+                                invitedList,
+                                "Event Waitlist Update",
+                                "Thank you for your participation in joining the waitlist for " + event.getName() + ".",
+                                "",
+                                UUID.randomUUID().toString(),
+                                timestamp
+                        );
+                        db.addNotification(notification);
+                    } else {
+                        Toast.makeText(OrganizerNotificationActivity.this, "There are no entrants in your event waitlist!", Toast.LENGTH_LONG).show();
+                    }
+                    //});
+
+                }
+
+                // Send to confirmed entrants
+                if (checkConfirmed.isChecked()) {
+                    Log.d("Notification(confirmed)", "This is confirmed action: ");
+                    ArrayList<String> confirmedList = event.getEnrolledList();
+                    if (confirmedList != null) {
+                        Notifications notification = new Notifications(
+                                confirmedList,
+                                "Thank you for confirming your attendance to " + event.getName() + "!",
+                                "Mark your calendars for your event details.",
+                                "",
+                                //"Thank you for confirming your attendance to " + event.getName() + "!"
+                                UUID.randomUUID().toString(),
+                                timestamp
+                        );
+
+                    } else {
+                        Toast.makeText(OrganizerNotificationActivity.this, "There are no confirmed entrants in your event!", Toast.LENGTH_LONG).show();
+                    }
+
+                }
+                // Send to cancelled entrants
+                if (checkCancelled.isChecked()) {
+                    Log.d("Notification(cancelled)", "This is cancelled action: ");
+                    ArrayList<String> cancelledList = event.getCancelledList();
+                    if (cancelledList != null) {
+                        Notifications notification = new Notifications(
+                                cancelledList,
+                                "Registration Cancel Confirmation",
+                                "You have been cancelled to enroll for " + event.getName() + ". We appreciate your consideration in joining. Hope to see you in future events!",
+                                "",
+                                UUID.randomUUID().toString(),
+                                timestamp
+                        );
+                        db.addNotification(notification);
+                    } else {
+                        Toast.makeText(OrganizerNotificationActivity.this, "There are no entrants that have cancelled your event!", Toast.LENGTH_LONG).show();
+                    }
+                }
+
+
+                Toast.makeText(OrganizerNotificationActivity.this, "Notification sent!", Toast.LENGTH_LONG).show();
+            }
+        });
+
+
+        binding.customNotifButton.setOnClickListener(new View.OnClickListener()
+        {
+            /**
+             * set details of event lists
+             * @param view The view that was clicked.
+             */
+            @Override
+            public void onClick(View view){
+                sendCustomNotification(checkInvited, checkWaitlist, checkConfirmed, checkCancelled, entrantsChecks);
+            }
+
+            private void sendCustomNotification(CheckBox checkInvited, CheckBox checkWaitlist, CheckBox checkConfirmed, CheckBox checkCancelled, ArrayList<CheckBox> entrantsChecks) {
+                if (!checkInvited.isChecked() && !checkWaitlist.isChecked() && !checkConfirmed.isChecked() && !checkCancelled.isChecked()) {
+                    Toast.makeText(OrganizerNotificationActivity.this, "Please select the entrant(s) you want to send a notification to!", Toast.LENGTH_LONG).show();
+                    return;
+                }
+
+                String newNotifTitle = notifTitleInput.getText().toString();
+                String newSmallText = smallTextInput.getText().toString();
+                String newBigText = bigTextInput.getText().toString();
+                Date timestamp = new Date();
+
+                if (newNotifTitle.isEmpty() || newSmallText.isEmpty()){
+                    Toast.makeText(OrganizerNotificationActivity.this, "Please enter a valid notification title and description.", Toast.LENGTH_LONG).show();
+                    return;
+                }
+//                if (newBigText.isEmpty()) {
+//                    newBigText = "";
+//                }
+                ArrayList<String> notificationEntrants = new ArrayList<>();
+                if (checkInvited.isChecked()) {
+                    notificationEntrants.addAll(event.getInvitedList());
+                }
+                if(checkWaitlist.isChecked()) {
+                    notificationEntrants.addAll(event.getWaitList());
+                }
+                if(checkConfirmed.isChecked()) {
+                    notificationEntrants.addAll(event.getEnrolledList());
+                }
+                if(checkCancelled.isChecked()) {
+                    notificationEntrants.addAll(event.getCancelledList());
+                }
+                Notifications notification = new Notifications(
+                        notificationEntrants,
+                        newNotifTitle,
+                        newSmallText,
+                        newBigText,
+                        //"Thank you for confirming your attendance to " + event.getName() + "!"
+                        UUID.randomUUID().toString(),
+                        timestamp);
+
+                    db.addNotification(notification);
+                Toast.makeText(OrganizerNotificationActivity.this, "Notification sent!", Toast.LENGTH_LONG).show();
+
+            }
+        });
     }
-
-    /**
-     * Organizer sends a notification based on the type of entrant they selected to send to
-     * @param checkInvited   entrants invited to event
-     * @param checkWaitlist  entrants in waitlist for event
-     * @param checkConfirmed entrants who confirmed registration for event
-     * @param checkCancelled entrants who cancelled invitation to event
-     */
-    private void sendNotification(CheckBox checkInvited, CheckBox checkWaitlist, CheckBox checkConfirmed, CheckBox checkCancelled) {
-
-        Date timestamp = new Date();
-        // Send to invited entrants
-        if (checkInvited.isChecked()) {
-            Log.d("Notification(invited)", "This is invited action: ");
-            ArrayList<String> invitedList = event.getInvitedList();
-            if (invitedList != null) {
-                Notifications notification = new Notifications(
-                        invitedList,
-                        "You Are Invited!",
-                        "Congratulations, you are invited to the event" + event.getName() + "!",
-                        "Accept your invitation to confirm your registration.",
-                        //"Thank you for confirming your attendance to " + event.getName() + "!"
-                        UUID.randomUUID().toString(),
-                        timestamp
-                );
-                db.addNotification(notification);
-            } else {
-                Toast.makeText(this, "There are no invited entrants in your event!", Toast.LENGTH_LONG).show();
-            }
-        }
-        // send wait list entrants
-        if (checkWaitlist.isChecked()) {
-            Log.d("Notification(waitlist)", "This is waitlist action: ");
-            //Log.d("Notification(waitlist)", "Event object: " + event);
-            //entrantDB.getEntrantList(event.getWaitList()).thenAccept(entrants -> {
-            ArrayList<String> invitedList = event.getWaitList();
-            Log.d("Notification(waitlist)", "Event object: " + event.getWaitList());
-            if (invitedList != null) {
-                Notifications notification = new Notifications(
-                        invitedList,
-                        "Event Waitlist Update",
-                        "Thank you for your participation in joining the waitlist for " + event.getName() + ".",
-                        "",
-                        //"Thank you for confirming your attendance to " + event.getName() + "!"
-                        UUID.randomUUID().toString(),
-                        timestamp
-                );
-                db.addNotification(notification);
-            } else {
-                Toast.makeText(this, "There are no entrants in your event waitlist!", Toast.LENGTH_LONG).show();
-            }
-            //});
-
-        }
-
-        // Send to confirmed entrants
-        if (checkConfirmed.isChecked()) {
-            Log.d("Notification(confirmed)", "This is confirmed action: ");
-            ArrayList<String> confirmedList = event.getEnrolledList();
-            if (confirmedList != null) {
-                Notifications notification = new Notifications(
-                        confirmedList,
-                        "Thank you for confirming your attendance to " + event.getName() + "!",
-                        "Mark your calendars for your event details.",
-                        "",
-                        //"Thank you for confirming your attendance to " + event.getName() + "!"
-                        UUID.randomUUID().toString(),
-                        timestamp
-                );
-                db.addNotification(notification);
-            } else {
-                Toast.makeText(this, "There are no confirmed entrants in your event!", Toast.LENGTH_LONG).show();
-            }
-
-        }
-        // Send to cancelled entrants
-        if (checkCancelled.isChecked()) {
-            Log.d("Notification(cancelled)", "This is cancelled action: ");
-            ArrayList<String> cancelledList = event.getCancelledList();
-            if (cancelledList != null) {
-                Notifications notification = new Notifications(
-                        cancelledList,
-                        "Registration Cancel Confirmation",
-                        "You have been cancelled to enroll for " + event.getName() + ". We appreciate your consideration in joining. Hope to see you in future events!",
-                        "",
-                        UUID.randomUUID().toString(),
-                        timestamp
-                );
-                db.addNotification(notification);
-            } else {
-                Toast.makeText(this, "There are no entrants that have cancelled your event!", Toast.LENGTH_LONG).show();
-            }
-        }
-
-
-        Toast.makeText(this, "Notification(s) sent!", Toast.LENGTH_LONG).show();
-
-    }
-
-
 }

--- a/bubbletracksapp/app/src/main/java/com/example/bubbletracksapp/OrganizerNotificationActivity.java
+++ b/bubbletracksapp/app/src/main/java/com/example/bubbletracksapp/OrganizerNotificationActivity.java
@@ -129,7 +129,7 @@ public class OrganizerNotificationActivity extends AppCompatActivity {
                         Notifications notification = new Notifications(
                                 invitedList,
                                 "You Are Invited!",
-                                "Congratulations, you are invited to the event" + event.getName() + "!",
+                                "Congratulations, you are invited to the event " + event.getName() + "!",
                                 "Accept your invitation to confirm your registration.",
                                 //"Thank you for confirming your attendance to " + event.getName() + "!"
                                 UUID.randomUUID().toString(),
@@ -169,16 +169,16 @@ public class OrganizerNotificationActivity extends AppCompatActivity {
                     Log.d("Notification(confirmed)", "This is confirmed action: ");
                     ArrayList<String> confirmedList = event.getEnrolledList();
                     if (confirmedList != null) {
+                        Log.d("Notification(confirmed)", "check list: " + confirmedList);
                         Notifications notification = new Notifications(
                                 confirmedList,
                                 "Thank you for confirming your attendance to " + event.getName() + "!",
                                 "Mark your calendars for your event details.",
                                 "",
-                                //"Thank you for confirming your attendance to " + event.getName() + "!"
                                 UUID.randomUUID().toString(),
                                 timestamp
                         );
-
+                        db.addNotification(notification);
                     } else {
                         Toast.makeText(OrganizerNotificationActivity.this, "There are no confirmed entrants in your event!", Toast.LENGTH_LONG).show();
                     }

--- a/bubbletracksapp/app/src/main/res/layout/notification_main.xml
+++ b/bubbletracksapp/app/src/main/res/layout/notification_main.xml
@@ -44,7 +44,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:paddingTop="8dp"
-            android:text="Select the type of entrant you want to send notifications to."
+            android:text="Select the type of entrant you want to send notifications to. You may choose between sending a default notification or a custom one."
             android:textAlignment="viewStart"
             android:textColor="@color/black"
             android:textSize="16sp" />
@@ -73,14 +73,14 @@
             android:layout_height="wrap_content"
             android:text="Notify Cancelled Entrants" />
 
-        <TextView
-            android:layout_width="wrap_content"
+        <Button
+            android:id="@+id/default_notif_button"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:paddingTop="8dp"
-            android:text="A default notification message is sent if no custom notification has been made."
-            android:textAlignment="viewStart"
-            android:textColor="@color/black"
-            android:textSize="16sp" />
+            android:layout_marginTop="16dp"
+            android:backgroundTint="#00FF00"
+            android:text="Send a Default Notification" />
+
 
         <TextView
             android:layout_width="wrap_content"
@@ -89,13 +89,13 @@
             android:textSize="16sp"
             android:textColor="@color/black"
             android:paddingTop="8dp" />
-        <TextView
+        <EditText
             android:id="@+id/notif_title"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:paddingTop="24dp"
             android:paddingBottom="8dp"
-            android:text="Notification Title"
+            android:hint="Notification Title"
             android:textSize="16sp"
             android:textColor="#555555"
             android:background="#EEEEEE"
@@ -108,13 +108,14 @@
             android:textSize="16sp"
             android:textColor="@color/black"
             android:paddingTop="8dp" />
-        <TextView
+
+        <EditText
             android:id="@+id/notif_small_text"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:paddingTop="24dp"
             android:paddingBottom="8dp"
-            android:text="Notification Description"
+            android:hint="Notification Description"
             android:textSize="16sp"
             android:textColor="#555555"
             android:background="#EEEEEE"
@@ -127,25 +128,24 @@
             android:textSize="16sp"
             android:textColor="@color/black"
             android:paddingTop="8dp" />
-        <TextView
+        <EditText
             android:id="@+id/notif_big_text"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:paddingTop="24dp"
             android:paddingBottom="8dp"
-            android:text="Extra Notification Details(Optional)"
+            android:hint="Extra Notification Details(Optional)"
             android:textSize="16sp"
             android:textColor="#555555"
             android:background="#EEEEEE"
             android:padding="8dp" />
 
-
         <Button
-            android:id="@+id/button_confirm"
+            android:id="@+id/custom_notif_button"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="16dp"
             android:backgroundTint="#00FF00"
-            android:text="Notify Attendees" />
+            android:text="Send Custom Notification" />
     </LinearLayout>
 </ScrollView>


### PR DESCRIPTION
Closes #32, #33, #34, and #25.

To test,:

- You need at least 2 devices. One for organizer and one for entrant.
-You can either follow the steps for the entrant to join the organizers event, or directly add your entrant device id to the lists (waitlist, enrolled, cancelled, invited) in your Firestore events document. 

- Go to the notifications activity the hosted events screen, and input your custom notification. Make sure to check off the type of entrant you want to send the notification to.
- Your entrant device should see the custom notification, and the notification document should be created.

